### PR TITLE
Parallel concept algorithm implemented

### DIFF
--- a/src/main/clojure/conexp/fca/contexts.clj
+++ b/src/main/clojure/conexp/fca/contexts.clj
@@ -483,6 +483,54 @@
         empty-att     (object-derivation ctx empty-obj)]
     (generate-from empty-obj empty-att 0)))
 
+(defn parallel-concepts
+  "Computes concepts based on max-recursions and proseccors.
+    ctx         the formal context
+    recursions  maximal number of recursion to generate entry point
+    processors  number of processors to compute result for all entry points
+  Based on 'Parallel algorithm for computing fixpoints of Galois connections'
+  Krajca; Oitrata; Vychodil 2010
+  https://link.springer.com/article/10.1007/s10472-010-9199-5"
+  [ctx recursions processors]
+  (let [n                (count (attributes ctx)),
+        attribute        (vec (attributes ctx)),
+        att-extent       (vec (map #(attribute-derivation ctx #{%}) attribute)),
+        initial-concepts (atom []),
+        generate-points  (fn generate-points [A B y i]
+                           (if (not= i recursions)
+                             (do
+                               (swap! initial-concepts conj [A B])
+                               (when (not= B (attributes ctx))
+                                   (mapcat (fn [j]
+                                             (when-not (contains? B (attribute j))
+                                               (let [C (intersection A (att-extent j)),
+                                                     D (object-derivation ctx C)]
+                                                 (when (cbo-test attribute j B D)
+                                                   (generate-points C D (inc j) (inc i))))))
+                                           (range y n))))
+                               (list [A B y]))),
+        generate-from    (fn generate-from [A B y]
+                           (cons [A B]
+                                 (when (not= B (attributes ctx))
+                                   (mapcat (fn [j]
+                                             (when-not (contains? B (attribute j))
+                                               (let [C (intersection A (att-extent j)),
+                                                     D (object-derivation ctx C)]
+                                                 (when (cbo-test attribute j B D)
+                                                   (generate-from C D (inc j))))))
+                                           (range y n))))),
+        empty-obj        (attribute-derivation ctx #{}),
+        empty-att        (object-derivation ctx empty-obj),
+        load-points      (generate-points empty-obj empty-att 0 1),
+        load-size        (max 1
+                              (int (+ (/ (count load-points) processors) 0.5)))]
+  (distinct 
+    (concat
+      @initial-concepts
+      (reduce concat 
+              (pmap #(mapcat (fn [a] (apply generate-from a)) %)
+                    (partition load-size load-size (list) load-points)))))))
+
 ;;; Common Operations with Contexts
 
 (defn dual-context

--- a/src/test/clojure/conexp/fca/contexts_test.clj
+++ b/src/test/clojure/conexp/fca/contexts_test.clj
@@ -352,6 +352,13 @@
              (<= (count (attributes ctx)) 15))
         (every? #(concept? ctx %) (concepts ctx)))))
 
+(deftest test-parallel-concepts
+  (with-testing-data [ctx testing-data]
+    (=> (and (<= (count (objects ctx)) 15)
+             (<= (count (attributes ctx)) 15))
+        (= (set (parallel-concepts ctx 2 4))
+           (set (concepts ctx))))))
+
 (deftest test-intents
   (with-testing-data [ctx testing-data]
     (=> (and (<= (count (objects ctx)) 15)


### PR DESCRIPTION
Tl;dr: Implemented paper algorithm -> Normal 'concepts' was many times faster -> Found out it already uses optimized single processor version of said algorithm -> Modified normal concepts algorithm to build new parallel-concepts which now is faster depending on settings.