### PR TITLE
Add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+eval "$(lorri direnv)"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignoresrc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1635165013,
+        "narHash": "sha256-o/BdVjNwcB6jOmzZjOH703BesSkkS5O7ej3xhyO8hAY=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "5b9e0ff9d3b551234b4f3eb3983744fa354b17f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1639989170,
+        "narHash": "sha256-REf0rqdJs6XIPo/zc/FhJMecggjEXi45QyiV207y30Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "86453059bf8312f0f5bf1fe8a2f52da2be664489",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignoresrc": "gitignoresrc",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "conexp-clj, a general purpose software tool for Formal Concept Analysis";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    gitignoresrc = {
+      url = "github:hercules-ci/gitignore.nix";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        gitignoreSource = (import inputs.gitignoresrc { inherit (pkgs) lib; }).gitignoreSource;
+        conexp-clj = pkgs.callPackage ./nix/conexp-clj
+          {
+            inherit gitignoreSource;
+          };
+      in
+      rec {
+        packages = flake-utils.lib.flattenTree {
+          conexp-clj = conexp-clj;
+        };
+        defaultPackage = packages.conexp-clj;
+        apps.conexp-clj = flake-utils.lib.mkApp { drv = packages.conexp-clj; };
+        defaultApp = apps.conexp-clj;
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            clojure-lsp
+            leiningen
+          ];
+          shellHook = ''
+            export "PATH=${conexp-clj}/bin:$PATH"
+          '';
+        };
+      });
+}

--- a/nix/conexp-clj/default.nix
+++ b/nix/conexp-clj/default.nix
@@ -1,0 +1,49 @@
+{ pkgs
+, lib
+, stdenv
+, makeWrapper
+, strip-nondeterminism
+, gitignoreSource
+, leiningen
+, jdk
+}:
+
+let dependencies = pkgs.callPackage ./dependencies.nix { inherit gitignoreSource leiningen; };
+in
+stdenv.mkDerivation rec {
+  pname = "conexp-clj";
+  version = "2.3.0-SNAPSHOT";
+  src = gitignoreSource ../..;
+
+  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ leiningen ];
+
+  preBuild = ''
+    mkdir -p $out
+    mkdir -p $out/maven
+    cp -R ${dependencies}/.m2 $out/maven
+    chmod -R +w $out/maven
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$PWD
+    export LEIN_HOME=$HOME/.lein
+    mkdir -p $LEIN_HOME
+
+    _JAVA_OPTIONS="-Duser.home=$out/maven" lein -o uberjar
+
+    runHook postBuild
+  '';
+
+  postFixup = ''
+    ${strip-nondeterminism}/bin/strip-nondeterminism $out/${pname}-${version}-standalone.jar
+  '';
+
+  installPhase = ''
+    cp builds/uberjar/${pname}-${version}-standalone.jar $out
+    makeWrapper ${jdk}/bin/java $out/bin/${pname} --add-flags "-jar $out/${pname}-${version}-standalone.jar"
+    makeWrapper ${leiningen}/bin/lein $out/bin/lein --add-flags "-o" --set "_JAVA_OPTIONS" "-Duser.home=$out/maven"
+  '';
+}

--- a/nix/conexp-clj/dependencies.nix
+++ b/nix/conexp-clj/dependencies.nix
@@ -1,0 +1,37 @@
+{ pkgs
+, lib
+, stdenv
+, gitignoreSource
+, leiningen
+}:
+
+stdenv.mkDerivation {
+  name = "conexp-clj-dependencies";
+  nativeBuildInputs = [ leiningen ];
+  src = gitignoreSource ../..;
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$PWD
+    export LEIN_HOME=$HOME/.lein
+    mkdir -p $LEIN_HOME
+
+    _JAVA_OPTIONS="-Duser.home=$out" lein with-profile uberjar,dev,debug deps
+    # hack to get repl dependencies into the repo
+    echo | _JAVA_OPTIONS="-Duser.home=$out" lein repl
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\|maven-metadata-local\.xml\)' -delete
+
+    runHook postInstall
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "sha256-o+DQDDs3Ch+cGuMoFGB6xGFwJKBM/946X6bFzlBiaVo=";
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  {
+    src = ./.;
+  }).shellNix


### PR DESCRIPTION
This packages `conexp-clj` as a Nix flake. It provides an app (for `nix run`), a package (for use in, e.g., a system configuration or another flake), and a devshell (for local development) that provides a wrapped `lein` with all dependencies provided.