### PR TITLE
Bump flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /doc/icfca-2013-tutorial/icfca2013-tutorial-talk.toc
 /doc/icfca-2013-tutorial/icfca2013-tutorial-talk.vrb
 /doc/tutorials/icfca-2013/icfca2013-tutorial-live.html
+/.lsp/

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     "gitignoresrc": {
       "flake": false,
       "locked": {
-        "lastModified": 1635165013,
-        "narHash": "sha256-o/BdVjNwcB6jOmzZjOH703BesSkkS5O7ej3xhyO8hAY=",
+        "lastModified": 1646480205,
+        "narHash": "sha256-kekOlTlu45vuK2L9nq8iVN17V3sB0WWPqTTW3a2SQG0=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "5b9e0ff9d3b551234b4f3eb3983744fa354b17f1",
+        "rev": "bff2832ec341cf30acb3a4d3e2e7f1f7b590116a",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1639989170,
-        "narHash": "sha256-REf0rqdJs6XIPo/zc/FhJMecggjEXi45QyiV207y30Y=",
+        "lastModified": 1650921206,
+        "narHash": "sha256-RGlfTC2ktqLVw0gBvZeCM//B4ig2CdQJm39sDvm0DBQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "86453059bf8312f0f5bf1fe8a2f52da2be664489",
+        "rev": "3a9e0f239d80fa134e8fcbdee4dfc793902da37e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -37,9 +37,6 @@
             clojure-lsp
             leiningen
           ];
-          shellHook = ''
-            export "PATH=${conexp-clj}/bin:$PATH"
-          '';
         };
       });
 }

--- a/nix/conexp-clj/dependencies.nix
+++ b/nix/conexp-clj/dependencies.nix
@@ -33,5 +33,5 @@ stdenv.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "sha256-o+DQDDs3Ch+cGuMoFGB6xGFwJKBM/946X6bFzlBiaVo=";
+  outputHash = "sha256-Kk5hx+CasiiQd5qYENbcOpq+DymomsiJIsTRdYLRtBg=";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -10,4 +10,4 @@
   )
   {
     src = ./.;
-  }).shellNix
+  }).shellNix.default


### PR DESCRIPTION
Bump the `nixpkgs` version of the flake, as well as update the hash of the depedencies on clojars. Also don't put `conexp-clj` in the devShell PATH to allow the devShell to still work when the build fails; a shell with `conexp-clj` in PATH is still available via `nix shell`.

#87 should probably be fixed before merging this.