### PR TITLE
New context randomization

### DIFF
--- a/src/main/clojure/conexp/fca/random_contexts.clj
+++ b/src/main/clojure/conexp/fca/random_contexts.clj
@@ -3,8 +3,9 @@
   (:require [conexp.fca.implications :refer [canonical-base]]
             [conexp.base :refer [set-of exists forall => defalias]]
             [conexp.fca.contexts :as contexts]
-            [clojure.set :refer [subset?]]
-            [clojure.math.numeric-tower :refer :all] 
+            [clojure.set :refer [subset? difference union intersection select]]
+            [clojure.math.numeric-tower :refer :all]
+            [clojure.math.combinatorics :refer [cartesian-product]]
             )
   (:import [org.apache.commons.math3.distribution
             GammaDistribution 
@@ -270,5 +271,126 @@
     (contexts/make-context (map inc (range num_objects)) attr  new-incidence)))
 
 
+(defn- filter-full-and-empty-rows-and-columns-once
+  "remove all full columns and full rows and return the respective subcontext"
+  [K]
+  (let [G (contexts/objects K)
+        M (contexts/attributes K)
+        Gfiltered (select (fn [g] (let [gprime (contexts/object-derivation K [g])]
+                                    (and (not= M gprime) (not= #{} gprime))))
+                          G)
+        Mfiltered (select (fn [m] (let [mprime (contexts/attribute-derivation K [m])]
+                                    (and (not= G mprime) (not= #{} mprime))))
+                          M)]
+    (contexts/make-context Gfiltered Mfiltered (contexts/incidence K))))
 
+
+(defn- filter-full-and-empty-rows-and-columns
+  "remove all full columns/rows repeatedly from the context K until each remaining column/row has at least one 'x' and one '.'.
+  return the set of objects and attributes that remain"
+  [K]
+  (loop [G (contexts/objects K)
+         M (contexts/attributes K)
+         K K]
+    (let [Kfiltered (filter-full-and-empty-rows-and-columns-once K)
+          Gfiltered (contexts/objects Kfiltered)
+          Mfiltered (contexts/attributes Kfiltered)]
+      (if (and (= G Gfiltered) (= M Mfiltered))
+        Kfiltered
+        (recur Gfiltered
+               Mfiltered
+               Kfiltered)))))
+
+
+(defn randomize-context-by-edge-swapping
+  "Given K=(G,M,I) swap incidences repeatedly selecting two objects and two attributes and swapping their incidences:
+  |x|.|    |.|x| 
+  |.|x| -> |x|.|
+  i.e., selecting g,h in G and m,n in M such that (g,m),(h,n) in I, (g,n),(h,m) not in I, and then swapping the incidences.
+  "
+  ([K]
+   (randomize-context-by-edge-swapping K (* 10 (count (contexts/incidence-relation K)))))
+  ([K iterations]
+   (assert (>= iterations 0)
+           "need a positive number of iterations")
+   (assert (not= (count (contexts/incidence-relation K)) 0)
+           "context has empty incidence relation; no swaps possible")
+   (assert (not= (count (contexts/incidence-relation K)) (* (count (contexts/objects K))
+                                                            (count (contexts/attributes K))))
+           "context has full incidence relation; no swaps possible")
+   (let [G (contexts/objects K)
+         M (contexts/attributes K)
+         Kswappable (filter-full-and-empty-rows-and-columns K) ; obtain the subcontext where swapping edges is possible (to reduce the occurrence of failed swap attempts)
+         Gfiltered (contexts/objects Kswappable)
+         Mfiltered (contexts/attributes Kswappable)
+         ]
+     (loop [i 0 ;iteration counter
+            j 0 ;failed iteration counter
+            Kswappable Kswappable 
+            I (contexts/incidence-relation K)]
+       (if (>= j (+ 100 iterations))
+         (do (println "Randomization stopped after " i
+                      " successful swaps and " j " failed swap attempts")
+             (contexts/make-context G M I)) 
+         (if (>= i iterations)
+           ;; (do (println "Randomization stopped after " i
+           ;;              " successful swaps and " j " failed swap attempts")
+           ;;     (contexts/make-context G M I)) 
+           (contexts/make-context G M I)
+           (let [g (rand-nth (into [] Gfiltered))
+                 gprime (contexts/object-derivation Kswappable [g])
+                 m (rand-nth (into [] gprime))
+                 n (rand-nth (into [] (difference Mfiltered gprime)))
+                 mprime (contexts/attribute-derivation Kswappable [m])
+                 nprime (contexts/attribute-derivation Kswappable [n])
+                 hpool (intersection (difference Gfiltered mprime)
+                                     nprime)]
+             (if (= #{} hpool) ; if there is no suitable object count the iteration as failed and repeat
+               (recur i
+                      (inc j)
+                      Kswappable
+                      I)
+               (let [h (rand-nth (into [] hpool))]
+                 ;; (println "remove " [g m] [h n])
+                 ;; (println "add " [g n] [h m])
+                 (let [Inew (union (difference I #{[g m] [h n]}) #{[g n] [h m]})]
+                   (recur (inc i)
+                          j
+                          (contexts/make-context Gfiltered Mfiltered Inew)
+                          Inew)))))))))))
+
+(alias imitate-context-with-edge-swapping randomize-context-by-edge-swapping)
+
+
+(defn randomize-context-by-edge-rewiring
+  "Given K=(G,M,I) randomize the incidence relation by repeatedly doing the following: select (g,m) in I, (h,n) not in I then add (h,n) to I and remove (g,m) from I"
+  ([K]
+   (randomize-context-by-edge-rewiring K (* 10 (count (contexts/incidence-relation K)))))
+  ([K iterations]
+   (assert (>= iterations 0)
+           "need a positive number of iterations")
+   (assert (not= (count (contexts/incidence-relation K)) 0)
+           "context has empty incidence relation; no rewiring possible")
+   (assert (not= (count (contexts/incidence-relation K)) (* (count (contexts/objects K))
+                                                            (count (contexts/attributes K))))
+           "context has full incidence relation; no rewiring possible")
+   (let [G (contexts/objects K)
+         M (contexts/attributes K)]
+     (loop [i 0
+            I (contexts/incidence-relation K)
+            IC (difference (into #{} (map vec (cartesian-product G M)))I)]
+       (if (>= i iterations)
+         (contexts/make-context G M I)
+         (let [[g m] (rand-nth (into [] I))
+               [h n] (rand-nth (into [] IC))]
+           (recur (inc i)
+                  (-> I
+                      (disj [g m])
+                      (conj [h n]))
+                  (-> IC
+                      (disj [h n])
+                      (conj [g m]))
+                  )))))))
+
+(alias imitate-context-with-edge-rewiring randomize-context-by-edge-rewiring)
 nil

--- a/src/main/clojure/conexp/fca/random_contexts.clj
+++ b/src/main/clojure/conexp/fca/random_contexts.clj
@@ -359,7 +359,7 @@
                           (contexts/make-context Gfiltered Mfiltered Inew)
                           Inew)))))))))))
 
-(alias imitate-context-with-edge-swapping randomize-context-by-edge-swapping)
+(defalias imitate-context-with-edge-swapping randomize-context-by-edge-swapping)
 
 
 (defn randomize-context-by-edge-rewiring
@@ -392,5 +392,5 @@
                       (conj [g m]))
                   )))))))
 
-(alias imitate-context-with-edge-rewiring randomize-context-by-edge-rewiring)
+(defalias imitate-context-with-edge-rewiring randomize-context-by-edge-rewiring)
 nil

--- a/src/test/clojure/conexp/fca/random_contexts_test.clj
+++ b/src/test/clojure/conexp/fca/random_contexts_test.clj
@@ -43,3 +43,29 @@
   (is (satisfies? Context (random-dirichlet-context :attributes 7
                                                     :objects 15
                                                     :precision-parameter (* 0.2 8)))))
+
+(def K (make-context #{0 7 1 4 6 3 2 9 5 8}
+                     #{"att_0" "att_5" "att_6" "att_4" "att_1" "att_7" "att_2" "att_3"}
+                     #{[2 "att_5"] [8 "att_6"] [9 "att_4"] [5 "att_3"] [0 "att_7"]
+                       [7 "att_0"] [3 "att_1"] [4 "att_3"] [9 "att_5"] [3 "att_5"]
+                       [0 "att_3"] [4 "att_2"] [1 "att_7"] [5 "att_4"] [4 "att_6"]
+                       [5 "att_1"] [7 "att_7"] [8 "att_0"] [9 "att_1"] [8 "att_2"]
+                       [0 "att_6"] [0 "att_5"] [6 "att_3"] [5 "att_7"] [1 "att_5"]
+                       [3 "att_0"] [6 "att_4"] [2 "att_4"] [4 "att_5"] [6 "att_2"]
+                       [9 "att_7"] [1 "att_4"] [2 "att_1"] [4 "att_7"] [0 "att_1"]
+                       [1 "att_2"] [2 "att_7"] [7 "att_1"] [2 "att_0"] [9 "att_6"]
+                       [6 "att_7"] [7 "att_6"] [8 "att_7"] [1 "att_3"] [8 "att_1"]
+                       [7 "att_5"] [6 "att_1"] [5 "att_6"] [3 "att_6"] [3 "att_7"]}))
+
+(deftest test-context-edge-swapping
+  (is (= (objects K) (objects (randomize-context-by-edge-swapping K))))
+  (is (= (attributes K) (attributes (randomize-context-by-edge-swapping K))))
+  (doseq [r (range 10)]
+    (is (= (count (incidence-relation K)) (count (incidence-relation (randomize-context-by-edge-swapping K)))))))
+
+
+(deftest test-context-edge-rewiring
+  (is (= (objects K) (objects (randomize-context-by-edge-rewiring K))))
+  (is (= (attributes K) (attributes (randomize-context-by-edge-rewiring K))))
+  (doseq [r (range 10)]
+    (is (= (count (incidence-relation K)) (count (incidence-relation (randomize-context-by-edge-rewiring K)))))))


### PR DESCRIPTION
Added the functions 
- randomize-context-by-edge-swapping
- randomize-context-by-edge-rewiring
to allow for randomization of contexts (G M I) via edge swapping 
([g m] [h n] in I , [g n] [h m] not in I -> [g n] [h m] in I , [g m] [h n] not in I)
and edge rewiring
([g m] in I, [h n] not in I -> [h n] in I, [g m] not in I)

and also added some simple tests