### PR TITLE
Feature/fix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663760840,
-        "narHash": "sha256-ym5Iycs5H4cOaLfE2/vC0tsLp8XuBJQIHGV8/uXSy8M=",
+        "lastModified": 1672580127,
+        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9bdbbaa634aa666eb6a27096bdcb991c59181244",
+        "rev": "0874168639713f547c05947c76124f78441ea46c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
           };
 
           devShells.default = mkShell {
-            buildinputs = with channels.nixpkgs; [ clojure-lsp leiningen ];
+            buildInputs = with channels.nixpkgs; [ clojure-lsp leiningen ];
           };
 
           formatter = channels.nixpkgs.alejandra;


### PR DESCRIPTION
Fix a typo in the flake, which prevented the `devShell` from working correctly.