### PR TITLE
add lein-aot-order plugin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,8 @@
                        :dependencies [[javax.servlet/servlet-api "2.5"]
                                       [ring/ring-mock "0.4.0"]
                                       [nrepl/nrepl "0.6.0"]]
-                       :aot :all}
+                       :plugins [[lein-aot-order "0.1.0"]]
+                       :aot :order}
              :dev {:main conexp.main
                    :dependencies [[javax.servlet/servlet-api "2.5"]
                                   [ring/ring-mock "0.4.0"]


### PR DESCRIPTION
lein uberjar could not be executed due to problems with the Order protocol and AOT compilation.
This was fixed by determining the compilation order with the lein-aot-order plugin.