### PR TITLE
Update flake

### DIFF
--- a/deps-lock.json
+++ b/deps-lock.json
@@ -693,6 +693,16 @@
       "hash": "sha256-/D20nRP2Bh7bFXdK1aKnsnnqUaqQCXCHmIsFqAbez/8="
     },
     {
+      "mvn-path": "lein-aot-order/lein-aot-order/0.1.0/lein-aot-order-0.1.0.jar",
+      "mvn-repo": "https://repo.clojars.org/",
+      "hash": "sha256-PGcHu8j/oxbKfp+ycSeV+pLl0DrwEEaIwabHV4GLaYk="
+    },
+    {
+      "mvn-path": "lein-aot-order/lein-aot-order/0.1.0/lein-aot-order-0.1.0.pom",
+      "mvn-repo": "https://repo.clojars.org/",
+      "hash": "sha256-Hpa5ikINI0zKEBDuoCGWToy8mAK1ohdqp5nvBDioFD8="
+    },
+    {
       "mvn-path": "luposlip/json-schema/0.4.1/json-schema-0.4.1.jar",
       "mvn-repo": "https://repo.clojars.org/",
       "hash": "sha256-pgkJvS1IZEGc0g3FEJpu3eI+Uldyh2cLP4cFXlk9ftg="
@@ -1218,6 +1228,11 @@
       "hash": "sha256-Z1wrqAzN8w47VMhNaZ5dZT5wfz8xPElsJagMuTx/e6o="
     },
     {
+      "mvn-path": "org/clojure/clojure/1.4.0/clojure-1.4.0.jar",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-TF5AycYSlMrYPnz2fsZhT2C4PcA3zrVFRu4QN8Jr1sg="
+    },
+    {
       "mvn-path": "org/clojure/clojure/1.4.0/clojure-1.4.0.pom",
       "mvn-repo": "https://repo1.maven.org/maven2/",
       "hash": "sha256-/5umkvBz16TfvI+otOQvbuPYyAsYBD5yx75dPOrTyyE="
@@ -1413,6 +1428,16 @@
       "hash": "sha256-4cCY6XzbWh+9Bu9zMtMDl5MlaQM4YRbZj0ZINxikzMU="
     },
     {
+      "mvn-path": "org/clojure/java.classpath/0.2.3/java.classpath-0.2.3.jar",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-nsZDMTCnJVv0I5Fzsd82LB5ic15cDIPdgbTrrzfwKDE="
+    },
+    {
+      "mvn-path": "org/clojure/java.classpath/0.2.3/java.classpath-0.2.3.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-d27PvZLMmNCM+ZeN5iclDYhti10RlCIh0dZ5siiA59A="
+    },
+    {
       "mvn-path": "org/clojure/java.classpath/0.3.0/java.classpath-0.3.0.jar",
       "mvn-repo": "https://repo1.maven.org/maven2/",
       "hash": "sha256-IXb2vtNMWGdd99VNgUZloJEY+yZfGuZm3hlg88uxUQ4="
@@ -1558,9 +1583,29 @@
       "hash": "sha256-I2Pi1bhg6NlXcr0z2mIO8+Ww+/OCHDSSQT9ftqJI3b4="
     },
     {
+      "mvn-path": "org/clojure/tools.namespace/0.3.0-alpha3/tools.namespace-0.3.0-alpha3.jar",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-6ok9330fVndKPbgRmD3g4LQOPh+lrkEhxWplKJEJEzE="
+    },
+    {
+      "mvn-path": "org/clojure/tools.namespace/0.3.0-alpha3/tools.namespace-0.3.0-alpha3.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-I43i5Sa45yr56RCN2P5NjwVEGwqy3A/kLU8lutFy61M="
+    },
+    {
       "mvn-path": "org/clojure/tools.reader/0.10.0-alpha3/tools.reader-0.10.0-alpha3.pom",
       "mvn-repo": "https://repo1.maven.org/maven2/",
       "hash": "sha256-EE60zx3DmRcTb/FT1KevfEmmjxK73667naNvOG3+MJo="
+    },
+    {
+      "mvn-path": "org/clojure/tools.reader/0.10.0/tools.reader-0.10.0.jar",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-N9qaFTfvZ83Ew12Ok9M2xUmEwgVPy7uQxQuzOR2jqBI="
+    },
+    {
+      "mvn-path": "org/clojure/tools.reader/0.10.0/tools.reader-0.10.0.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-0gGx38KTjKfQqx3pFpp5IgjA3kVjehbEvxAFfjiqzuw="
     },
     {
       "mvn-path": "org/clojure/tools.reader/1.3.6/tools.reader-1.3.6.jar",

--- a/flake.lock
+++ b/flake.lock
@@ -12,23 +12,25 @@
         ]
       },
       "locked": {
-        "lastModified": 1663854702,
-        "narHash": "sha256-gnoyYWvZl64WBqR3tf9bKHAznEtBCHmwx7taHghH9Lw=",
-        "owner": "mmarx",
+        "lastModified": 1677342613,
+        "narHash": "sha256-BqhKj7jQahSVThEwLHt164kJHGx9LXzBARFZaFNLPW8=",
+        "owner": "jlesquembre",
         "repo": "clj-nix",
-        "rev": "10b1e9544811c07e02c536872fcd6a6aeed96ba7",
+        "rev": "7d9e244ea96988524ba3bd6c2bbafdf0a5340b96",
         "type": "github"
       },
       "original": {
-        "owner": "mmarx",
-        "ref": "fix-lein",
+        "owner": "jlesquembre",
         "repo": "clj-nix",
         "type": "github"
       }
     },
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "clj-nix",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "clj-nix",
           "nixpkgs"
@@ -49,21 +51,6 @@
       }
     },
     "flake-utils": {
-      "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -100,16 +87,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672580127,
-        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "lastModified": 1685451684,
+        "narHash": "sha256-Y5iqtWkO82gHAnrBvNu/yLQsiVNJRCad4wWGz2a1urk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "rev": "6b0edc9c690c1d8a729f055e0d73439045cfda55",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -124,7 +111,7 @@
     },
     "utils": {
       "inputs": {
-        "flake-utils": "flake-utils_2"
+        "flake-utils": "flake-utils"
       },
       "locked": {
         "lastModified": 1657226504,

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
 
           conexp = let
             pname = "conexp-clj";
-            version = "2.3.0-SNAPSHOT";
+            version = "2.3.1-SNAPSHOT";
           in mkCljBin rec {
             name = "conexp/${pname}";
             inherit version;

--- a/flake.nix
+++ b/flake.nix
@@ -3,13 +3,11 @@
     "conexp-clj, a general purpose software tool for Formal Concept Analysis";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     utils.url = "github:gytis-ivaskevicius/flake-utils-plus";
 
     clj-nix = {
-      #url = "github:jlesquembre/clj-nix";
-      url =
-        "github:mmarx/clj-nix/fix-lein"; # we need to wait for PR 31 to go through.
+      url = "github:jlesquembre/clj-nix";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "utils/flake-utils";

--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,8 @@
                        :dependencies [[javax.servlet/servlet-api "2.5"]
                                       [ring/ring-mock "0.4.0"]
                                       [nrepl/nrepl "1.0.0"]]
-                       :aot :all}
+                       :plugins [[lein-aot-order "0.1.0"]]
+                       :aot :order}
              :dev {:main conexp.main
                    :dependencies [[javax.servlet/servlet-api "2.5"]
                                   [ring/ring-mock "0.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -52,6 +52,7 @@
                    :dependencies [[javax.servlet/servlet-api "2.5"]
                                   [ring/ring-mock "0.4.0"]
                                   [nrepl/nrepl "1.0.0"]]
+                   :plugins [[lein-aot-order "0.1.0"]]
                    :javac-options ["-Xlint:deprecation" "-Xlint:unchecked"]}
              :gorilla {:main conexp.main
                        :plugins [[org.clojars.benfb/lein-gorilla "0.7.0"]]}}


### PR DESCRIPTION
Update the flake, fixing `nix run`:
 - bump to current nixpkgs stable(*),
 - bump `conexp` version number to `2.3.1`, matching `project.clj`, and
 - include `lein-aot-order` in the main profile, to force it being picked up by `deps-lock`.

Depends on #112 being merged. Note that `nix run` was already broken before due to AOT issues.

(*) technically not released yet, but scheduled for later today ;)