### PR TITLE
Avoid duplicating the version number in `flake.nix`

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -13,5 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v17
-      - run: nix run .#test
+      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/magic-nix-cache-action@v2
+      - run: nix flake check

--- a/.github/workflows/update-deps-lock.yaml
+++ b/.github/workflows/update-deps-lock.yaml
@@ -10,9 +10,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v17
+      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/magic-nix-cache-action@v2
       - name: Update deps-lock
-        run: "nix run .#deps-lock"
+        run: nix run .#deps-lock
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4.0.3

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 /doc/tutorials/icfca-2013/icfca2013-tutorial-live.html
 /.lsp/
 /.direnv/
+/.clj-kondo/

--- a/flake.lock
+++ b/flake.lock
@@ -3,20 +3,17 @@
     "clj-nix": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": [
-          "utils",
-          "flake-utils"
-        ],
+        "nix-fetcher-data": "nix-fetcher-data",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1677342613,
-        "narHash": "sha256-BqhKj7jQahSVThEwLHt164kJHGx9LXzBARFZaFNLPW8=",
+        "lastModified": 1689754411,
+        "narHash": "sha256-DBaZAmBR5EA03Zjf4k7XHqvOovJP+pFhzl+BJ4V+lFw=",
         "owner": "jlesquembre",
         "repo": "clj-nix",
-        "rev": "7d9e244ea96988524ba3bd6c2bbafdf0a5340b96",
+        "rev": "6a017fb2bc7b60c9e67b1c6f0b04bbefcf8dc698",
         "type": "github"
       },
       "original": {
@@ -27,27 +24,59 @@
     },
     "devshell": {
       "inputs": {
-        "flake-utils": [
-          "clj-nix",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "clj-nix",
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1658746384,
-        "narHash": "sha256-CCJcoMOcXyZFrV1ag4XMTpAPjLWb4Anbv+ktXFI1ry0=",
+        "lastModified": 1687944744,
+        "narHash": "sha256-4ZtRVG/5yWHPZpkit1Ak5Mo1DDnkx1AG1HpNu/P+n5U=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "0ffc7937bb5e8141af03d462b468bd071eb18e1b",
+        "rev": "3864857b2754ab0e16c7c7c626f0e5a1d4e42f38",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "devshell",
         "type": "github"
+      }
+    },
+    "flake-part": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1685546676,
+        "narHash": "sha256-XDbjJyAg6odX5Vj0Q22iI/gQuFvEkv9kamsSbQ+npaI=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "6ef2707776c6379bc727faf3f83c0dd60b06e0c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1685546676,
+        "narHash": "sha256-XDbjJyAg6odX5Vj0Q22iI/gQuFvEkv9kamsSbQ+npaI=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "6ef2707776c6379bc727faf3f83c0dd60b06e0c6",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
       }
     },
     "flake-utils": {
@@ -85,18 +114,77 @@
         "type": "github"
       }
     },
+    "nix-fetcher-data": {
+      "inputs": {
+        "flake-part": "flake-part",
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "clj-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685572850,
+        "narHash": "sha256-lYKEqFG9F84xu51H1rM1u+Ip88cINL0+W26sT+vFEZc=",
+        "owner": "jlesquembre",
+        "repo": "nix-fetcher-data",
+        "rev": "f14967db6c92c79b77419f52c22a698518c91120",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jlesquembre",
+        "repo": "nix-fetcher-data",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685451684,
-        "narHash": "sha256-Y5iqtWkO82gHAnrBvNu/yLQsiVNJRCad4wWGz2a1urk=",
+        "lastModified": 1689605451,
+        "narHash": "sha256-u2qp2k9V1smCfk6rdUcgMKvBj3G9jVvaPHyeXinjN9E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b0edc9c690c1d8a729f055e0d73439045cfda55",
+        "rev": "53657afe29748b3e462f1f892287b7e254c26d77",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -107,6 +195,21 @@
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "utils": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,13 @@
     mkFlake {
       inherit self inputs;
 
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+
       channels.nixpkgs.overlaysBuilder = channels: [inputs.clj-nix.overlays.default];
 
       overlays.default = final: prev: {
@@ -91,6 +98,11 @@
                 lein test $@
               '';
             };
+        };
+
+        checks = {
+          inherit (packages) conexp-clj;
+          devShell = devShells.default;
         };
 
         devShells.default = mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,13 @@
             name = "conexp/${pname}";
             version = versionFromDefproject pname;
 
+            meta = {
+              description =
+                "A General-Purpose Tool for Formal Concept Analysis";
+              homepage = "https://github.com/tomhanika/conexp-clj";
+              license = channels.nixpkgs.lib.licenses.epl10;
+            };
+
             projectSrc = gitignoreSource ./.;
             main-ns = "conexp";
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,7 @@
 
     clj-nix = {
       url = "github:jlesquembre/clj-nix";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "utils/flake-utils";
-      };
+      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     gitignore = {
@@ -64,16 +61,13 @@
             checkPhase = "lein test";
           };
 
-        in {
-          packages = rec {
+        in rec {
+          packages = {
             conexp-clj = conexp;
-            default = conexp-clj;
+            default = conexp;
           };
 
           apps = rec {
-            conexp-clj = mkApp { drv = conexp; };
-            default = conexp-clj;
-
             deps-lock = mkApp {
               drv = writeShellScriptBin "deps-lock" ''
                 ${channels.nixpkgs.deps-lock}/bin/deps-lock --lein $@

--- a/flake.nix
+++ b/flake.nix
@@ -37,13 +37,20 @@
           inherit (inputs.gitignore.lib) gitignoreSource;
           inherit (inputs.clj-nix.lib) mk-deps-cache;
           inherit (channels.nixpkgs) mkCljBin mkShell writeShellScriptBin;
+          inherit (channels.nixpkgs.lib) pipe;
 
           conexp = let
+            versionFromDefproject = name:
+              pipe ./project.clj [
+                builtins.readFile
+                (builtins.match ''
+                  .*\([[:SPACE:]]*defproject[[:SPACE:]]+${name}[[:SPACE:]]+"([^"]+)".*'')
+                builtins.head
+              ];
             pname = "conexp-clj";
-            version = "2.4.1-SNAPSHOT";
           in mkCljBin rec {
             name = "conexp/${pname}";
-            inherit version;
+            version = versionFromDefproject pname;
 
             projectSrc = gitignoreSource ./.;
             main-ns = "conexp";


### PR DESCRIPTION
This reads the version number from `project.clj`. Also slightly cleans up the flake structure, getting rid of superfluous apps (which, e.g., don't harmonise with `nix bundle`), and build the package as part of `nix flake check` (which runs the unit tests as part of the `checkPhase`). Lastly, add the magic nix cache action for the CI workflows.