### PR TITLE
CI: also run tests on master branch

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,9 +3,11 @@ on:
   pull_request:
     branches:
       - dev
+      - master
   push:
     branches:
       - dev
+      - master
 
 jobs:
   unit-tests:


### PR DESCRIPTION
The workflow only triggered on dev, but the README build badge points at ?branch=master, so master had zero runs and the badge showed 'no status'. Add master to the push + pull_request triggers so the release branch is CI-covered and the badge reflects it.