### PR TITLE
Make DimFlux usable on larger lattices

### DIFF
--- a/doc/DimFlux.org
+++ b/doc/DimFlux.org
@@ -67,13 +67,14 @@ A map given directly after the lattice overrides the defaults in
 (dim-flux-layout ctx {} "greedy")
 #+end_src
 
-| Parameter       | Meaning                                                          | Default |
-|-----------------+------------------------------------------------------------------+---------|
-| ~:w-rep~        | weight of the repulsion between nodes and non-incident edges      |    50.0 |
-| ~:w-att~        | weight of the attraction along the edges                          |     1.0 |
-| ~:w-grav~       | weight of the gravitation keeping the element vectors oriented    |    30.0 |
-| ~:iterations~   | bound on the number of conjugate gradient iterations              |    1000 |
-| ~:min-distance~ | smallest conflict distance the repulsive energy is evaluated at   |   0.001 |
+| Parameter       | Meaning                                                          |   Default |
+|-----------------+------------------------------------------------------------------+-----------|
+| ~:initial~      | the diagram the refinement starts from                            | ~:dim-draw~ |
+| ~:w-rep~        | weight of the repulsion between nodes and non-incident edges      |      50.0 |
+| ~:w-att~        | weight of the attraction along the edges                          |       1.0 |
+| ~:w-grav~       | weight of the gravitation keeping the element vectors oriented    |      30.0 |
+| ~:iterations~   | bound on the number of conjugate gradient iterations              |      1000 |
+| ~:min-distance~ | smallest conflict distance the repulsive energy is evaluated at   |     0.001 |
 
 The refinement is a local optimization and may fail to produce a valid line
 diagram.  In that case ~dim-flux-layout~ falls back to the projected diagram,
@@ -101,6 +102,45 @@ exactly the case when it equals its own projection:
 Because the projection is cheap, it can also be applied after every step of an
 interactive edit: dragging a node destroys additivity, and projecting restores
 it, at the price of moving the other nodes along.
+
+** Larger lattices
+
+The exact two-dimension extension of DimDraw is what makes DimFlux expensive,
+and it grows very steeply: on random contexts it takes about a second at 16
+concepts and half a minute at 23.  Everything else is cheap by comparison.  The
+~:initial~ parameter therefore chooses the diagram the refinement starts from:
+
+#+begin_src clojure :results silent
+(dim-flux-layout ctx {:initial :dim-draw})            ;; the algorithm of the paper
+(dim-flux-layout ctx {:initial :greedy})              ;; greedy two-dimension extension
+(dim-flux-layout ctx {:initial :layered})             ;; no DimDraw at all
+(dim-flux-layout ctx {:initial inf-additive-layout})  ;; any layout function
+#+end_src
+
+Measured on random contexts, with the smallest distance between a node and a
+non-incident edge as the quality measure, taken after scaling each diagram to
+unit height:
+
+| concepts | ~:dim-draw~ | ~:greedy~ | ~:layered~ |
+|----------+-------------+-----------+------------|
+|       16 | 1.0 s       | 0.1 s     | 0.05 s     |
+|       23 | 32 s        | 0.2 s     | 0.06 s     |
+|       36 | not run     | 1.3 s     | 0.4 s      |
+|      108 | not run     | 39 s      | 2.3 s      |
+
+| concepts | ~:dim-draw~ | ~:greedy~ | ~:layered~ |
+|----------+-------------+-----------+------------|
+|       16 |      0.0813 |    0.0565 |     0.0239 |
+|       23 |      0.0263 |    0.0031 |     0.0000 |
+|       36 | not run     |    0.0024 |     0.0001 |
+|      108 | not run     |    0.0001 |     0.0000 |
+
+Quality tracks the starting diagram closely, so the cheaper modes buy speed with
+readability rather than for free.  A sensible rule of thumb is ~:dim-draw~ up to
+about 20 concepts, ~:greedy~ up to about 40, and ~:layered~ beyond that, keeping
+in mind that a line diagram of a hundred concepts is hard to read whatever draws
+it.  The refinement itself is bounded by ~:iterations~, which is the knob to turn
+when a single lattice takes surprisingly long.
 
 ** Limitations
 

--- a/doc/DimFlux.org
+++ b/doc/DimFlux.org
@@ -113,34 +113,71 @@ concepts and half a minute at 23.  Everything else is cheap by comparison.  The
 #+begin_src clojure :results silent
 (dim-flux-layout ctx {:initial :dim-draw})            ;; the algorithm of the paper
 (dim-flux-layout ctx {:initial :greedy})              ;; greedy two-dimension extension
+(dim-flux-layout ctx {:initial :planarity-enhancer})  ;; the paper's own alternative
 (dim-flux-layout ctx {:initial :layered})             ;; no DimDraw at all
 (dim-flux-layout ctx {:initial inf-additive-layout})  ;; any layout function
 #+end_src
 
-Measured on random contexts, with the smallest distance between a node and a
-non-incident edge as the quality measure, taken after scaling each diagram to
-unit height:
+~:planarity-enhancer~ is the alternative the paper itself offers, and
+~planarity-enhancer-layout~ can also be called on its own.  It lays the
+irreducible elements out by a spring model whose rest lengths are their sup-inf
+distances, reads a linear order off the longest axis of that layout, and then
+places atoms and coatoms on two opposing parabolas and everything else by chain
+decomposition.  Its cost is quadratic in the number of irreducible elements
+rather than in the number of concepts, which is why it stays near a tenth of a
+second even on a lattice of a hundred elements.
 
-| concepts | ~:dim-draw~ | ~:greedy~ | ~:layered~ |
-|----------+-------------+-----------+------------|
-|       16 | 1.0 s       | 0.1 s     | 0.05 s     |
-|       23 | 32 s        | 0.2 s     | 0.06 s     |
-|       36 | not run     | 1.3 s     | 0.4 s      |
-|      108 | not run     | 39 s      | 2.3 s      |
+Measured on random contexts, time for the whole algorithm and, as a quality
+measure, the smallest distance between a node and a non-incident edge after
+scaling the diagram to unit height:
 
-| concepts | ~:dim-draw~ | ~:greedy~ | ~:layered~ |
-|----------+-------------+-----------+------------|
-|       16 |      0.0813 |    0.0565 |     0.0239 |
-|       23 |      0.0263 |    0.0031 |     0.0000 |
-|       36 | not run     |    0.0024 |     0.0001 |
-|      108 | not run     |    0.0001 |     0.0000 |
+| concepts | ~:dim-draw~ | ~:greedy~ | ~:planarity-enhancer~ | ~:layered~ |
+|----------+-------------+-----------+-----------------------+------------|
+|       16 | 1.1 s       | 0.06 s    | 0.08 s                | 0.05 s     |
+|       23 | 32 s        | 0.13 s    | 0.10 s                | 0.05 s     |
+|       36 | not run     | 0.8 s     | 0.3 s                 | 0.4 s      |
+|       70 | not run     | 7 s       | 0.4 s                 | 20 s       |
+|      108 | not run     | 35 s      | 51 s                  | 2 s        |
 
-Quality tracks the starting diagram closely, so the cheaper modes buy speed with
-readability rather than for free.  A sensible rule of thumb is ~:dim-draw~ up to
-about 20 concepts, ~:greedy~ up to about 40, and ~:layered~ beyond that, keeping
-in mind that a line diagram of a hundred concepts is hard to read whatever draws
-it.  The refinement itself is bounded by ~:iterations~, which is the knob to turn
-when a single lattice takes surprisingly long.
+| concepts | ~:dim-draw~ | ~:greedy~ | ~:planarity-enhancer~ | ~:layered~ |
+|----------+-------------+-----------+-----------------------+------------|
+|       16 |      0.0813 |    0.0184 |                0.0582 |     0.0239 |
+|       23 |      0.0263 |    0.0129 |                0.0195 |     0.0000 |
+|       36 | not run     |    0.0008 |                0.0076 |     0.0001 |
+|       70 | not run     |    0.0002 |                0.0001 |     0.0000 |
+|      108 | not run     |    0.0001 |                0.0007 |     0.0000 |
+
+Up to roughly 25 concepts ~:dim-draw~ still gives the best diagram and is worth
+its price; past that the planarity enhancer gives the best diagram of the
+remaining three and is usually also the fastest.
+
+*** Bounding the refinement
+
+Where the enhancer is used, the time is no longer spent on the initial diagram
+at all.  Of the 51 seconds at 108 concepts, the enhancer accounts for 0.1 and the
+projection for 0.3; the rest is the force-directed refinement running to its
+iteration cap.  That cap is ~:iterations~, and it has sharply diminishing
+returns:
+
+| iterations | 29 concepts     | 79 concepts    | 108 concepts    |
+|------------+-----------------+----------------+-----------------|
+|          0 | 0.2 s / 0.0003  | 0.2 s / 0.0001 | 0.3 s / 0.0000  |
+|         25 | 0.2 s / 0.0055  | 1.0 s / 0.0004 | 1.7 s / 0.0003  |
+|         50 | 0.2 s / 0.0071  | 1.9 s / 0.0005 | 3.4 s / 0.0004  |
+|        100 | 0.2 s / 0.0071  | 3.6 s / 0.0015 | 6.5 s / 0.0004  |
+|        250 | 0.2 s / 0.0071  | 8.0 s / 0.0014 | 15 s / 0.0007   |
+|       1000 | 0.2 s / 0.0071  | 21 s / 0.0014  | 51 s / 0.0007   |
+
+Below about 30 concepts the refinement converges long before the cap, so the
+default of 1000 costs nothing.  Above it, 100 to 250 iterations buy nearly all
+the improvement there is:
+
+#+begin_src clojure :results silent
+(dim-flux-layout ctx {:initial :planarity-enhancer :iterations 250})
+#+end_src
+
+The default is left at 1000 so that the algorithm as published is what you get
+unless you ask for something else.
 
 ** Limitations
 

--- a/src/main/clojure/conexp/layouts/dim_flux.clj
+++ b/src/main/clojure/conexp/layouts/dim_flux.clj
@@ -30,6 +30,7 @@
                                          lattice-upper-neighbours]]
             [conexp.layouts.base :as lay]
             [conexp.layouts.dim-draw :refer [dim-draw-layout]]
+            [conexp.layouts.layered :refer [simple-layered-layout]]
             [conexp.math.algebra :refer [base-set order]]
             [conexp.math.optimize :refer [minimize-with-gradient]])
   (:import [conexp.fca.lattices Lattice]
@@ -45,12 +46,17 @@
   paper, :iterations bounds the number of conjugate gradient iterations and
   :min-distance is the smallest conflict distance the repulsive energy is
   evaluated at, which keeps degenerate placements from producing infinite
-  energies."
+  energies.
+
+  :initial chooses the diagram the refinement starts from and is the parameter
+  to reach for on larger lattices, where the two-dimension extension of DimDraw
+  dominates the running time.  See `initial-layout`."
   {:w-rep          50.0
    :w-att           1.0
    :w-grav         30.0
    :iterations   1000
-   :min-distance    1.0e-3})
+   :min-distance    1.0e-3
+   :initial      :dim-draw})
 
 ;;; The doubly-additive set representation
 ;;
@@ -162,123 +168,160 @@
   "The repulsive energy `E_rep = sum_v sum_{v1v2} 1/d(w,f)`, taken over all nodes
   `v` and all edges `v1v2` not incident with `v`, together with the force it
   exerts on the element vectors.  Here `d` is the conflict distance between a
-  node and a non-incident edge, which the repulsion maximizes."
+  node and a non-incident edge, which the repulsion maximizes.
+
+  Only elements that can move the conflict distance at all are visited.  An
+  object matters exactly if it lies below the upper end of the edge but not
+  below the node, or below the node but not below the lower end; dually for an
+  attribute.  Both sets are intersections of words of the membership bit sets,
+  so the inner loop runs over a handful of elements instead of over all of
+  them."
   [model ^doubles pos]
-  (let [nc               (long (:nc model))
-        ne               (long (:ne model))
-        ng               (long (:ng model))
-        ^booleans member (:member model)
-        edges            (:edges model)
-        min-d            (double (:min-distance model))
-        force            (double-array (* 2 ne))
-        energy           (double-array 1)]
+  (let [nc              (long (:nc model))
+        ne              (long (:ne model))
+        ng              (long (:ng model))
+        words           (long (:words model))
+        ^"[[J" bits     (:bits model)
+        ^longs obj-mask (:object-mask model)
+        ^longs att-mask (:attribute-mask model)
+        ^ints edge-lo   (:edge-lo model)
+        ^ints edge-hi   (:edge-hi model)
+        n-edges         (alength edge-lo)
+        min-d           (double (:min-distance model))
+        force           (double-array (* 2 ne))
+        energy          (double-array 1)]
     (dotimes [c nc]
-      (let [wx (aget pos (* 2 c))
-            wy (aget pos (inc (* 2 c)))]
-        (doseq [[a b] edges
-                :when (and (not= c (long a)) (not= c (long b)))]
-          (let [v1   (long a)
-                v2   (long b)
-                w1x  (aget pos (* 2 v1)), w1y (aget pos (inc (* 2 v1)))
-                w2x  (aget pos (* 2 v2)), w2y (aget pos (inc (* 2 v2)))
-                fx   (- w2x w1x), fy (- w2y w1y)
-                flen (Math/max (Math/sqrt (+ (* fx fx) (* fy fy))) min-d)
-                d1   (Math/sqrt (+ (* (- w1x wx) (- w1x wx))
-                                   (* (- w1y wy) (- w1y wy))))
-                d2   (Math/sqrt (+ (* (- w2x wx) (- w2x wx))
-                                   (* (- w2y wy) (- w2y wy))))
-                ;; where the node lies relative to the edge
-                below? (> (+ (* (- w1x wx) fx) (* (- w1y wy) fy)) 0.0)
-                above? (< (+ (* (- w2x wx) fx) (* (- w2y wy) fy)) 0.0)
-                cross  (- (* (- w1x wx) (- w2y wy)) (* (- w1y wy) (- w2x wx)))
-                ;; +1 if the node lies left of the edge, -1 otherwise, so that
-                ;; the force always pushes it away
-                l      (double (if (>= cross 0.0) 1.0 -1.0))
-                dist   (Math/max min-d (double (cond below? d1
-                                                     above? d2
-                                                     :else  (/ (Math/abs cross) flen))))
-                scale  (/ 1.0 (* dist dist))
-                ;; direction the conflict distance grows in
-                ux     (double (cond below? (/ (- w1x wx) dist)
-                                     above? (/ (- w2x wx) dist)
-                                     :else  (/ (* (- fy) l) flen)))
-                uy     (double (cond below? (/ (- w1y wy) dist)
-                                     above? (/ (- w2y wy) dist)
-                                     :else  (/ (* fx l) flen)))
-                ;; scaled variants for elements moving only one end of the edge
-                s1     (/ (Math/sqrt (Math/abs (- (* d1 d1) (* dist dist)))) flen)
-                s2     (/ (Math/sqrt (Math/abs (- (* d2 d2) (* dist dist)))) flen)]
-            (aset energy 0 (+ (aget energy 0) (/ 1.0 dist)))
-            (dotimes [e ne]
-              (let [object? (< e ng)
-                    mv      (aget member (+ (* c ne) e))
-                    m1      (aget member (+ (* v1 ne) e))
-                    m2      (aget member (+ (* v2 ne) e))
-                    ;; the eight ways an element can be distributed over the node
-                    ;; and the two ends of the edge, numbered as in the paper
-                    k       (inc (bit-or (if mv 4 0) (if m1 2 0) (if m2 1 0)))
-                    ;; k = 1 and k = 8 leave the conflict distance untouched, the
-                    ;; other excluded cases contradict the order relation
-                    skip?   (or (= k 1) (= k 8)
-                                (if object?
-                                  (or (= k 3) (= k 7))
-                                  (or (= k 2) (= k 6))))
-                    factor  (double
-                             (if skip?
-                               0.0
-                               (cond
-                                 below?
-                                 (cond (if object? (= k 4) (or (= k 3) (= k 4)))   1.0
-                                       (if object? (or (= k 5) (= k 6)) (= k 5))  -1.0
-                                       :else                                       0.0)
-                                 above?
-                                 (cond (if object? (or (= k 2) (= k 4)) (= k 4))   1.0
-                                       (if object? (= k 5) (or (= k 5) (= k 7)))  -1.0
-                                       :else                                       0.0)
-                                 :else
-                                 (cond (and object? (= k 2))       (- s1)
-                                       (and (not object?) (= k 3)) (- s2)
-                                       (= k 4)                     -1.0
-                                       (= k 5)                      1.0
-                                       (and object? (= k 6))        s2
-                                       (and (not object?) (= k 7))  s1
-                                       :else                        0.0))))]
-                (when-not (zero? factor)
-                  (aset force (* 2 e)
-                        (+ (aget force (* 2 e)) (* scale factor ux)))
-                  (aset force (inc (* 2 e))
-                        (+ (aget force (inc (* 2 e))) (* scale factor uy))))))))))
+      (let [wx        (aget pos (* 2 c))
+            wy        (aget pos (inc (* 2 c)))
+            ^longs bc (aget bits c)]
+        (dotimes [ei n-edges]
+          (let [v1 (aget edge-lo ei)
+                v2 (aget edge-hi ei)]
+            (when (and (not= c v1) (not= c v2))
+              (let [^longs b1 (aget bits v1)
+                    ^longs b2 (aget bits v2)
+                    w1x  (aget pos (* 2 v1)), w1y (aget pos (inc (* 2 v1)))
+                    w2x  (aget pos (* 2 v2)), w2y (aget pos (inc (* 2 v2)))
+                    fx   (- w2x w1x), fy (- w2y w1y)
+                    flen (Math/max (Math/sqrt (+ (* fx fx) (* fy fy))) min-d)
+                    d1   (Math/sqrt (+ (* (- w1x wx) (- w1x wx))
+                                       (* (- w1y wy) (- w1y wy))))
+                    d2   (Math/sqrt (+ (* (- w2x wx) (- w2x wx))
+                                       (* (- w2y wy) (- w2y wy))))
+                    ;; where the node lies relative to the edge
+                    below? (> (+ (* (- w1x wx) fx) (* (- w1y wy) fy)) 0.0)
+                    above? (< (+ (* (- w2x wx) fx) (* (- w2y wy) fy)) 0.0)
+                    cross  (- (* (- w1x wx) (- w2y wy)) (* (- w1y wy) (- w2x wx)))
+                    ;; +1 if the node lies left of the edge, -1 otherwise, so
+                    ;; that the force always pushes it away
+                    l      (double (if (>= cross 0.0) 1.0 -1.0))
+                    dist   (Math/max min-d (double (cond below? d1
+                                                         above? d2
+                                                         :else  (/ (Math/abs cross) flen))))
+                    scale  (/ 1.0 (* dist dist))
+                    ;; direction the conflict distance grows in
+                    ux     (double (cond below? (/ (- w1x wx) dist)
+                                         above? (/ (- w2x wx) dist)
+                                         :else  (/ (* (- fy) l) flen)))
+                    uy     (double (cond below? (/ (- w1y wy) dist)
+                                         above? (/ (- w2y wy) dist)
+                                         :else  (/ (* fx l) flen)))
+                    ;; scaled variants for elements moving only one end of the edge
+                    s1     (/ (Math/sqrt (Math/abs (- (* d1 d1) (* dist dist)))) flen)
+                    s2     (/ (Math/sqrt (Math/abs (- (* d2 d2) (* dist dist)))) flen)]
+                (aset energy 0 (+ (aget energy 0) (/ 1.0 dist)))
+                (dotimes [w words]
+                  (let [bcw (aget bc w)
+                        b1w (aget b1 w)
+                        b2w (aget b2 w)
+                        relevant (bit-or
+                                  (bit-and (aget obj-mask w)
+                                           (bit-or (bit-and b2w (bit-not bcw))
+                                                   (bit-and bcw (bit-not b1w))))
+                                  (bit-and (aget att-mask w)
+                                           (bit-or (bit-and b1w (bit-not bcw))
+                                                   (bit-and bcw (bit-not b2w)))))]
+                    (loop [m (long relevant)]
+                      (when-not (zero? m)
+                        (let [b       (Long/numberOfTrailingZeros m)
+                              bit     (bit-shift-left 1 b)
+                              e       (+ (* w 64) b)
+                              object? (< e ng)
+                              ;; the eight ways an element can be distributed
+                              ;; over the node and the two ends of the edge,
+                              ;; numbered as in the paper
+                              k       (inc (bit-or (if (zero? (bit-and bcw bit)) 0 4)
+                                                   (if (zero? (bit-and b1w bit)) 0 2)
+                                                   (if (zero? (bit-and b2w bit)) 0 1)))
+                              factor  (double
+                                       (cond
+                                         below?
+                                         (cond (if object? (= k 4) (or (= k 3) (= k 4)))   1.0
+                                               (if object? (or (= k 5) (= k 6)) (= k 5))  -1.0
+                                               :else                                       0.0)
+                                         above?
+                                         (cond (if object? (or (= k 2) (= k 4)) (= k 4))   1.0
+                                               (if object? (= k 5) (or (= k 5) (= k 7)))  -1.0
+                                               :else                                       0.0)
+                                         :else
+                                         (cond (and object? (= k 2))       (- s1)
+                                               (and (not object?) (= k 3)) (- s2)
+                                               (= k 4)                     -1.0
+                                               (= k 5)                      1.0
+                                               (and object? (= k 6))        s2
+                                               (and (not object?) (= k 7))  s1
+                                               :else                        0.0)))]
+                          (when-not (zero? factor)
+                            (aset force (* 2 e)
+                                  (+ (aget force (* 2 e)) (* scale factor ux)))
+                            (aset force (inc (* 2 e))
+                                  (+ (aget force (inc (* 2 e))) (* scale factor uy)))))
+                        (recur (bit-and m (dec m)))))))))))))
     [(aget energy 0) force]))
 
 (defn- attractive-energy-and-force
   "The attractive energy `E_att = sum_{v1v2} |f|^2`, taken over all edges, which
   keeps the diagram from falling apart, together with the force it exerts on the
-  element vectors."
+  element vectors.
+
+  Only elements separating the two ends of an edge can shorten it: objects of
+  the upper end pull it down, attributes of the lower end pull it up.  Both sets
+  come straight out of the membership bit sets."
   [model ^doubles pos]
-  (let [ne               (long (:ne model))
-        ng               (long (:ng model))
-        ^booleans member (:member model)
-        force            (double-array (* 2 ne))
-        energy           (double-array 1)]
-    (doseq [[a b] (:edges model)]
-      (let [v1  (long a)
-            v2  (long b)
-            dx  (- (aget pos (* 2 v2)) (aget pos (* 2 v1)))
-            dy  (- (aget pos (inc (* 2 v2))) (aget pos (inc (* 2 v1))))]
+  (let [ne              (long (:ne model))
+        ng              (long (:ng model))
+        words           (long (:words model))
+        ^"[[J" bits     (:bits model)
+        ^longs obj-mask (:object-mask model)
+        ^longs att-mask (:attribute-mask model)
+        ^ints edge-lo   (:edge-lo model)
+        ^ints edge-hi   (:edge-hi model)
+        n-edges         (alength edge-lo)
+        force           (double-array (* 2 ne))
+        energy          (double-array 1)]
+    (dotimes [ei n-edges]
+      (let [v1        (aget edge-lo ei)
+            v2        (aget edge-hi ei)
+            ^longs b1 (aget bits v1)
+            ^longs b2 (aget bits v2)
+            dx        (- (aget pos (* 2 v2)) (aget pos (* 2 v1)))
+            dy        (- (aget pos (inc (* 2 v2))) (aget pos (inc (* 2 v1))))]
         (aset energy 0 (+ (aget energy 0) (* dx dx) (* dy dy)))
-        (dotimes [e ne]
-          (let [object? (< e ng)
-                m1      (aget member (+ (* v1 ne) e))
-                m2      (aget member (+ (* v2 ne) e))]
-            ;; only elements separating the two ends of an edge can shorten it:
-            ;; objects of the upper end pull it down, attributes of the lower end
-            ;; pull it up
-            (when (if object? (and m2 (not m1)) (and m1 (not m2)))
-              (let [sign (double (if object? -1.0 1.0))]
-                (aset force (* 2 e)
-                      (+ (aget force (* 2 e)) (* 2.0 sign dx)))
-                (aset force (inc (* 2 e))
-                      (+ (aget force (inc (* 2 e))) (* 2.0 sign dy)))))))))
+        (dotimes [w words]
+          (let [b1w (aget b1 w)
+                b2w (aget b2 w)
+                relevant (bit-or (bit-and (aget obj-mask w) b2w (bit-not b1w))
+                                 (bit-and (aget att-mask w) b1w (bit-not b2w)))]
+            (loop [m (long relevant)]
+              (when-not (zero? m)
+                (let [b    (Long/numberOfTrailingZeros m)
+                      e    (+ (* w 64) b)
+                      sign (double (if (< e ng) -1.0 1.0))]
+                  (aset force (* 2 e)
+                        (+ (aget force (* 2 e)) (* 2.0 sign dx)))
+                  (aset force (inc (* 2 e))
+                        (+ (aget force (inc (* 2 e))) (* 2.0 sign dy))))
+                (recur (bit-and m (dec m)))))))))
     [(aget energy 0) force]))
 
 (defn- gravitational-energy-and-force
@@ -391,6 +434,7 @@
         nm     (count attributes)
         ne     (+ ng nm)
         nc     (count nodes)
+        words  (max 1 (int (Math/ceil (/ ne 64.0))))
         member (membership-array lattice nodes objects attributes)
         index  (into {} (map-indexed (fn [i c] [c i]) nodes))]
     (merge parameters
@@ -404,6 +448,32 @@
             :node-elements (vec (for [c (range nc)]
                                   (int-array (filter #(aget ^booleans member (+ (* c ne) %))
                                                      (range ne)))))
+            ;; the membership relation once more, packed into words, so that the
+            ;; forces can single out the elements they have to look at
+            :words         words
+            :bits          (into-array
+                            (for [c (range nc)]
+                              (let [row (long-array words)]
+                                (dotimes [e ne]
+                                  (when (aget ^booleans member (+ (* c ne) e))
+                                    (aset row (quot e 64)
+                                          (bit-set (aget row (quot e 64)) (rem e 64)))))
+                                row)))
+            :object-mask   (let [mask (long-array words)]
+                             (dotimes [e ng]
+                               (aset mask (quot e 64)
+                                     (bit-set (aget mask (quot e 64)) (rem e 64))))
+                             mask)
+            :attribute-mask (let [mask (long-array words)]
+                              (dotimes [i nm]
+                                (let [e (+ ng i)]
+                                  (aset mask (quot e 64)
+                                        (bit-set (aget mask (quot e 64)) (rem e 64)))))
+                              mask)
+            :edge-lo       (int-array (for [n nodes, u (lattice-upper-neighbours lattice n)]
+                                        (index n)))
+            :edge-hi       (int-array (for [n nodes, u (lattice-upper-neighbours lattice n)]
+                                        (index u)))
             :edges         (vec (for [n nodes, u (lattice-upper-neighbours lattice n)]
                                   [(index n) (index u)]))})))
 
@@ -451,6 +521,44 @@
     (every? (fn [[a b]] (< (double (second (get pos a)))
                            (double (second (get pos b)))))
             (lay/connections layout))))
+
+(defn- rotated-dim-draw-layout
+  "The DimDraw diagram of `lattice`, scaled to the canonical aspect ratio of the
+  paper: the realizer coordinates are turned by 45 degrees, then stretched
+  horizontally and squeezed vertically."
+  [lattice dim-draw-args]
+  (let [layout (apply dim-draw-layout lattice dim-draw-args)]
+    (lay/update-positions
+     layout
+     (into {} (for [[c [x y]] (lay/positions layout)]
+                [c [(* (Math/sqrt 2.0) (double x))
+                    (/ (double y) (Math/sqrt 2.0))]])))))
+
+(defn initial-layout
+  "The diagram the force-directed refinement starts from, chosen by the :initial
+  parameter:
+
+    :dim-draw  the realizer-embedded diagram of DimDraw, using its exact
+               two-dimension extension.  This is the algorithm of the paper and
+               the default, and it is what dominates the running time as soon as
+               a lattice grows past roughly 25 elements.
+    :greedy    the same, but with the greedy two-dimension extension of DimDraw,
+               which gives up minimality of the inserted relation in exchange for
+               dropping the SAT search.
+    :layered   the simple layered layout, skipping DimDraw altogether.  The
+               cheapest start, and the one to use when the lattice is too large
+               for either DimDraw mode.
+
+  A function of the lattice returning a layout may be given instead, which is how
+  any other layout of conexp-clj can serve as the starting diagram."
+  [lattice parameters dim-draw-args]
+  (let [initial (:initial parameters :dim-draw)]
+    (cond
+      (fn? initial)         (initial lattice)
+      (= :dim-draw initial) (rotated-dim-draw-layout lattice dim-draw-args)
+      (= :greedy initial)   (rotated-dim-draw-layout lattice (cons "greedy" dim-draw-args))
+      (= :layered initial)  (simple-layered-layout lattice)
+      :else (illegal-argument "Unknown initial layout for DimFlux: " initial))))
 
 (defn- as-lattice
   "Returns the lattice to be drawn, accepting a lattice or a formal context."
@@ -511,11 +619,15 @@
   doubly-additive diagram and then refined by a force-directed placement
   maximizing the conflict distance between nodes and non-incident edges.  Should
   the refinement not yield a valid line diagram, the projected diagram is
-  returned instead, and should that one be invalid as well, the DimDraw diagram
+  returned instead, and should that one be invalid as well, the initial diagram
   is.
 
   When the first argument after the lattice is a map, it overrides
   `default-parameters`; all remaining arguments are passed on to DimDraw.
+
+  On lattices past roughly 25 elements the exact two-dimension extension of
+  DimDraw dominates the running time.  The :initial parameter then buys most of
+  it back, at the price of a weaker starting diagram; see `initial-layout`.
 
   See M. Nöhre, D. Dürrschnabel, B. Ganter, G. Stumme, `DimFlux:
   Force-Directed Additive Line Diagrams', International Journal of
@@ -528,21 +640,16 @@
                                      [default-parameters args])
         nodes                      (vec (base-set lattice))
         [objects attributes]       (irreducible-elements lattice)
-        ;; step 1: the realizer-embedded diagram of DimDraw, scaled to the
-        ;; canonical aspect ratio used in the paper
-        dim-draw                   (let [layout (apply dim-draw-layout lattice dim-draw-args)]
-                                     (lay/update-positions
-                                      layout
-                                      (into {} (for [[c [x y]] (lay/positions layout)]
-                                                 [c [(* (Math/sqrt 2.0) (double x))
-                                                     (/ (double y) (Math/sqrt 2.0))]]))))]
+        ;; step 1: the diagram to start from, by default the realizer-embedded
+        ;; one of DimDraw
+        start                      (initial-layout lattice parameters dim-draw-args)]
     (if (empty? (concat objects attributes))
-      dim-draw
+      start
       (let [model     (make-model lattice nodes objects attributes parameters)
             srm       (set-representation-matrix lattice nodes objects attributes)
             ;; step 2: the closest doubly-additive diagram, as element vectors
             initial   (element-vectors-of srm
-                                          (positions-array dim-draw nodes)
+                                          (positions-array start nodes)
                                           (count objects))
             projected (layout-of-vectors lattice nodes model initial)
             ;; step 3: force-directed refinement of the element vectors
@@ -559,7 +666,7 @@
         (cond
           (and optimized (respects-order? optimized)) optimized
           (respects-order? projected)                 projected
-          :else                                       dim-draw)))))
+          :else                                       start)))))
 
 ;;;
 

--- a/src/main/clojure/conexp/layouts/dim_flux.clj
+++ b/src/main/clojure/conexp/layouts/dim_flux.clj
@@ -24,7 +24,8 @@
   https://arxiv.org/abs/2603.16366"
   (:require [conexp.base :refer [illegal-argument]]
             [conexp.fca.contexts :refer [context?]]
-            [conexp.fca.lattices :refer [concept-lattice
+            [conexp.fca.lattices :refer [concept-lattice inf sup
+                                         lattice-atoms lattice-coatoms
                                          lattice-inf-irreducibles
                                          lattice-sup-irreducibles
                                          lattice-upper-neighbours]]
@@ -522,6 +523,231 @@
                            (double (second (get pos b)))))
             (lay/connections layout))))
 
+(defn- sup-inf-distances
+  "The doubly-additive sup-inf distance between every pair of irreducible
+  elements, as a flat `double[ne*ne]`.
+
+  For two incomparable elements the distance counts how much the interval
+  between their meet and their join spans.  Written over the standard context
+  this needs closures of unions of extents and intents, but the closure of a
+  union of extents is the extent of the join and dually for intents, so all four
+  quantities are just counts of irreducibles below the meet and above the join.
+  Comparable pairs get distance zero.
+
+  See Section 6.1 of the DimFlux paper, extending the sup-inf distance of
+  C. Zschalig from the attribute-additive to the doubly-additive case."
+  [lattice objects attributes]
+  (let [leq       (order lattice)
+        meet      (inf lattice)
+        join      (sup lattice)
+        elements  (vec (concat objects attributes))
+        ng        (count objects)
+        ne        (count elements)
+        object?   (fn [i] (< (long i) ng))
+        below     (memoize (fn [x] (count (filter #(leq % x) objects))))
+        above     (memoize (fn [x] (count (filter #(leq x %) attributes))))
+        out       (double-array (* ne ne))]
+    (doseq [i (range ne), j (range (inc (long i)) ne)]
+      (let [a (nth elements i)
+            b (nth elements j)
+            d (cond
+                ;; two objects, or two attributes
+                (= (object? i) (object? j))
+                (if (or (leq a b) (leq b a))
+                  0.0
+                  (if (object? i)
+                    (- (below (join a b)) (below (meet a b)) 1)
+                    (- (above (meet a b)) (above (join a b)) 1)))
+                ;; an object and an attribute; the reference implementation
+                ;; treats the pair as incomparable exactly when the object does
+                ;; not lie below the attribute
+                :else
+                (let [g (if (object? i) a b)
+                      m (if (object? i) b a)]
+                  (if (leq g m)
+                    0.0
+                    (let [meet-gm (meet g m)
+                          join-gm (join g m)]
+                      (- (- (below meet-gm) (above join-gm))
+                         (- (below join-gm) (above meet-gm))
+                         1)))))]
+        (aset out (+ (* (long i) ne) (long j)) (double d))
+        (aset out (+ (* (long j) ne) (long i)) (double d))))
+    out))
+
+(defn- spring-energy-and-gradient
+  "The energy `E_SI = sum_{i<j} (|n_i - n_j| - d_SI(i,j))^2` of the spring model
+  and its gradient, in one pass over the pairs."
+  [^doubles dsi ^long ne ^doubles p]
+  (let [grad   (double-array (* 2 ne))
+        energy (double-array 1)]
+    (dotimes [i ne]
+      (let [xi (aget p (* 2 i))
+            yi (aget p (inc (* 2 i)))]
+        (loop [j (inc i)]
+          (when (< j ne)
+            (let [dx (- xi (aget p (* 2 j)))
+                  dy (- yi (aget p (inc (* 2 j))))
+                  r  (Math/max (Math/sqrt (+ (* dx dx) (* dy dy))) 1.0e-9)
+                  t  (- r (aget dsi (+ (* i ne) j)))
+                  f  (* 2.0 (/ t r))]
+              (aset energy 0 (+ (aget energy 0) (* t t)))
+              (aset grad (* 2 i) (+ (aget grad (* 2 i)) (* f dx)))
+              (aset grad (inc (* 2 i)) (+ (aget grad (inc (* 2 i))) (* f dy)))
+              (aset grad (* 2 j) (- (aget grad (* 2 j)) (* f dx)))
+              (aset grad (inc (* 2 j)) (- (aget grad (inc (* 2 j))) (* f dy))))
+            (recur (inc j))))))
+    [(aget energy 0) grad]))
+
+(defn- spring-positions
+  "Places the irreducible elements in the plane so that their Euclidean
+  distances approximate the sup-inf distances, by minimizing
+
+      E_SI = sum_{i<j} (|n_i - n_j| - d_SI(i,j))^2
+
+  from a start on the unit circle.  Returns a flat `double[2*ne]`.
+
+  The minimization is bounded, because this is only the starting point of a
+  starting point: letting it run to convergence costs far more than the
+  refinement it feeds and moves the final diagram very little."
+  [^doubles dsi ^long ne parameters]
+  (let [start (mapcat (fn [i]
+                        (let [phi (/ (* 2.0 Math/PI i) ne)]
+                          [(Math/cos phi) (Math/sin phi)]))
+                      (range ne))
+        cache (atom nil)
+        both  (fn [^doubles p]
+                (let [key (vec p)]
+                  (if-let [[k r] @cache]
+                    (if (= k key)
+                      r
+                      (let [r (spring-energy-and-gradient dsi ne p)]
+                        (reset! cache [key r]) r))
+                    (let [r (spring-energy-and-gradient dsi ne p)]
+                      (reset! cache [key r]) r))))]
+    (double-array
+     (try (first (minimize-with-gradient
+                  (fn [^doubles p] (first (both p)))
+                  (fn [^doubles p] (seq ^doubles (second (both p))))
+                  start
+                  {:iterations      (:spring-iterations parameters 200)
+                   :max-evaluations (:spring-evaluations parameters 2000)}))
+          (catch Exception _ start)))))
+
+(defn- element-scalars
+  "Projects the spring layout onto the axis spanned by its two most distant
+  points, which turns it into the linear order of the irreducible elements the
+  placement then follows."
+  [^doubles pts ^long ne]
+  (let [pt   (fn [i] [(aget pts (* 2 (long i))) (aget pts (inc (* 2 (long i))))])
+        [i j] (if (< ne 2)
+                [0 0]
+                (apply max-key
+                       (fn [[a b]]
+                         (let [[ax ay] (pt a), [bx by] (pt b)]
+                           (+ (* (- bx ax) (- bx ax)) (* (- by ay) (- by ay)))))
+                       (for [a (range ne), b (range (inc (long a)) ne)] [a b])))
+        ;; the left of the two points anchors the axis
+        [n1 n2] (let [[ix _] (pt i), [jx _] (pt j)]
+                  (if (< (double ix) (double jx)) [(pt i) (pt j)] [(pt j) (pt i)]))
+        [n1x n1y] n1
+        [n2x n2y] n2
+        fx      (- (double n2x) (double n1x))
+        fy      (- (double n2y) (double n1y))]
+    (vec (for [k (range ne)]
+           (let [[x y] (pt k)]
+             (+ (* (- (double x) (double n1x)) fx)
+                (* (- (double y) (double n1y)) fy)))))))
+
+(defn- round-to-tenth
+  ^double [^double x]
+  (/ (Math/round (* 10.0 x)) 10.0))
+
+(defn planarity-enhancer-layout
+  "Returns the initial doubly-additive layout of `lattice` computed by the
+  planarity enhancer, the alternative to DimDraw offered by the DimFlux paper.
+
+  The irreducible elements are first laid out by a spring model whose rest
+  lengths are their sup-inf distances, which spreads apart those elements whose
+  chains would otherwise cross.  Projecting that layout onto its longest axis
+  gives a linear order.  Following it, the atoms are placed along an upward
+  parabola and the coatoms along its mirror image, and the remaining elements
+  are filled in by chain decomposition: an object goes to the mean of the
+  objects below it, an attribute to the mean of the attributes above it, each
+  shifted slightly so that elements sharing their neighbours do not coincide.
+
+  This costs time quadratic in the number of irreducible elements rather than in
+  the number of concepts, and involves no satisfiability search, which is what
+  makes it the cheap alternative to the two-dimension extension of DimDraw.
+
+  See Section 6.1 of the DimFlux paper and C. Zschalig, `A Force Directed
+  Approach to Drawing Concept Lattices', for the attribute-additive original."
+  ([lattice]
+   (planarity-enhancer-layout lattice default-parameters))
+  ([lattice parameters]
+   (let [[objects attributes] (irreducible-elements lattice)
+        ng       (count objects)
+        nm       (count attributes)
+        ne       (+ ng nm)
+        nodes    (vec (base-set lattice))]
+    (if (zero? ne)
+      (simple-layered-layout lattice)
+      (let [leq      (order lattice)
+            dsi      (sup-inf-distances lattice objects attributes)
+            scalars  (element-scalars (spring-positions dsi ne parameters) ne)
+            obj-idx  (into {} (map-indexed (fn [i g] [g i]) objects))
+            att-idx  (into {} (map-indexed (fn [i m] [m (+ ng i)]) attributes))
+            vectors  (double-array (* 2 ne))
+            place!   (fn [i x y]
+                       (aset vectors (* 2 (long i)) (double x))
+                       (aset vectors (inc (* 2 (long i))) (double y)))
+            ;; the atoms ride an upward parabola, the coatoms its mirror image,
+            ;; both spaced 1.8 apart and centred on the origin
+            parabola (fn [elements index up?]
+                       (let [ordered (sort-by #(nth scalars (index %)) elements)
+                             n       (count ordered)]
+                         (doseq [[k e] (map-indexed vector ordered)]
+                           (let [x (round-to-tenth (- (* 1.8 (inc (long k)))
+                                                      (* 0.9 (inc n))))
+                                 y (+ (* 0.09 x x) 1.75)]
+                             (if up?
+                               (place! (index e) x y)
+                               (place! (index e) (- x) (- y)))))))
+            _        (parabola (filter obj-idx (lattice-atoms lattice)) obj-idx true)
+            _        (parabola (filter att-idx (lattice-coatoms lattice)) att-idx false)
+            ;; chain decomposition, bottom up for objects and top down for
+            ;; attributes; a strictly ordered pass guarantees the neighbours are
+            ;; already placed
+            done-obj (atom (set (filter obj-idx (lattice-atoms lattice))))
+            done-att (atom (set (filter att-idx (lattice-coatoms lattice))))]
+        (doseq [g (sort-by #(count (filter (fn [h] (leq h %)) objects))
+                           (remove @done-obj objects))]
+          (let [lower (filter #(and (leq % g) (not= % g)) objects)]
+            (if (empty? lower)
+              (place! (obj-idx g) (* 1.0e-3 (obj-idx g)) 1.75)
+              (let [n  (count lower)
+                    mx (/ (reduce + (map #(aget vectors (* 2 (long (obj-idx %)))) lower)) n)
+                    my (/ (reduce + (map #(aget vectors (inc (* 2 (long (obj-idx %)))))
+                                         lower)) n)
+                    d  (* 1.0e-3 (obj-idx g))]
+                (place! (obj-idx g) (+ mx d) (+ my d))))
+            (swap! done-obj conj g)))
+        (doseq [m (sort-by #(- (count (filter (fn [k] (leq % k)) attributes)))
+                           (remove @done-att attributes))]
+          (let [upper (filter #(and (leq m %) (not= m %)) attributes)]
+            (if (empty? upper)
+              (place! (att-idx m) (* 1.0e-3 (att-idx m)) -1.75)
+              (let [n  (count upper)
+                    mx (/ (reduce + (map #(aget vectors (* 2 (long (att-idx %)))) upper)) n)
+                    my (/ (reduce + (map #(aget vectors (inc (* 2 (long (att-idx %)))))
+                                         upper)) n)
+                    d  (* 1.0e-3 (att-idx m))]
+                (place! (att-idx m) (+ mx d) (+ my d))))
+            (swap! done-att conj m)))
+        (layout-of-vectors lattice nodes
+                           (make-model lattice nodes objects attributes parameters)
+                           vectors))))))
+
 (defn- rotated-dim-draw-layout
   "The DimDraw diagram of `lattice`, scaled to the canonical aspect ratio of the
   paper: the realizer coordinates are turned by 45 degrees, then stretched
@@ -545,9 +771,13 @@
     :greedy    the same, but with the greedy two-dimension extension of DimDraw,
                which gives up minimality of the inserted relation in exchange for
                dropping the SAT search.
+    :planarity-enhancer
+               the initial layout of the paper's own alternative to DimDraw,
+               costing quadratic time in the number of irreducible elements
+               rather than in the number of concepts and using no satisfiability
+               search.  See `planarity-enhancer-layout`.
     :layered   the simple layered layout, skipping DimDraw altogether.  The
-               cheapest start, and the one to use when the lattice is too large
-               for either DimDraw mode.
+               cheapest start, and the crudest.
 
   A function of the lattice returning a layout may be given instead, which is how
   any other layout of conexp-clj can serve as the starting diagram."
@@ -558,6 +788,7 @@
       (= :dim-draw initial) (rotated-dim-draw-layout lattice dim-draw-args)
       (= :greedy initial)   (rotated-dim-draw-layout lattice (cons "greedy" dim-draw-args))
       (= :layered initial)  (simple-layered-layout lattice)
+      (= :planarity-enhancer initial) (planarity-enhancer-layout lattice parameters)
       :else (illegal-argument "Unknown initial layout for DimFlux: " initial))))
 
 (defn- as-lattice

--- a/src/test/clojure/conexp/layouts/dim_flux_test.clj
+++ b/src/test/clojure/conexp/layouts/dim_flux_test.clj
@@ -152,6 +152,42 @@
                                      (Double/isFinite (double y))))
                     (vals (lay/positions layout))))))))
 
+(def ^:private golden-positions
+  "Positions the default pipeline produced before the layout was made faster,
+  sorted by height and then by width.  They pin the algorithm as published: the
+  bit set forces and the choice of starting diagram are meant to leave this
+  untouched, and any change to it has to be a deliberate one."
+  {:dwarf-planets [[0.0                 0.0]
+                   [8.19935225251826    2.346964615822346]
+                   [1.5080519851248935  2.7503682438937167]
+                   [5.2663583159666185  3.63685157189151]
+                   [-2.5915881534869167 4.251313112569929]
+                   [9.187239538652053   7.566931803569037]
+                   [4.876583774118542   9.170601222949625]]
+   :crown         [[0.0                 0.0]
+                   [0.8466887913409333  4.330029082813631]
+                   [11.42214199577128   5.371920889808214]
+                   [-2.6619399196473585 5.781949703748222]
+                   [5.006672072366866   5.997766182579722]
+                   [-5.7242857395793    6.631734031383484]
+                   [1.9566450274783709  7.555458515492352]
+                   [-8.349016755546916  9.745757438424809]
+                   [8.092072349194877   10.722769863709924]
+                   [4.587945288778855   10.734761834827436]
+                   [1.6766024257904606  11.348615156481433]
+                   [-3.730431808421188  11.519266250168938]
+                   [-7.23906051940948   12.971186871103528]
+                   [2.4050407820196287  16.64311394470097]]})
+
+(deftest test-dim-flux-layout-is-unchanged
+  (doseq [[key ctx] {:dwarf-planets dwarf-planets, :crown crown}]
+    (testing (str "the default pipeline still draws " (name key) " as it did")
+      (let [drawn (sort-by (juxt second first) (vals (lay/positions (dim-flux-layout ctx))))]
+        (is (= (count (golden-positions key)) (count drawn)))
+        (doseq [[[gx gy] [x y]] (map vector (golden-positions key) drawn)]
+          (is (< (Math/abs (- (double gx) (double x))) 1.0e-9))
+          (is (< (Math/abs (- (double gy) (double y))) 1.0e-9)))))))
+
 (deftest test-dim-flux-layout-accepts-lattices
   (let [ctx  dwarf-planets
         from-context (dim-flux-layout ctx)

--- a/src/test/clojure/conexp/layouts/dim_flux_test.clj
+++ b/src/test/clojure/conexp/layouts/dim_flux_test.clj
@@ -171,7 +171,8 @@
 (deftest test-dim-flux-layout-initial
   (testing "every starting diagram yields a valid additive line diagram"
     (doseq [ctx      all-contexts
-            initial  [:dim-draw :greedy :layered simple-layered-layout]]
+            initial  [:dim-draw :greedy :planarity-enhancer :layered
+                      simple-layered-layout]]
       (let [layout (dim-flux-layout ctx {:initial initial})]
         (is (line-diagram? layout)
             (str "line diagram for " initial))
@@ -181,6 +182,22 @@
   (testing "an unknown starting diagram is rejected"
     (is (thrown? IllegalArgumentException
                  (dim-flux-layout dwarf-planets {:initial :nonsense})))))
+
+(deftest test-planarity-enhancer-layout
+  (doseq [ctx all-contexts]
+    (let [lattice (concept-lattice ctx)
+          layout  (planarity-enhancer-layout lattice)]
+      (testing "the enhancer alone already draws the lattice"
+        (is (= (base-set lattice) (set (keys (lay/positions layout)))))
+        (is (= (edges-of lattice) (set (lay/connections layout)))))
+      (testing "and does so as a doubly-additive line diagram"
+        (is (line-diagram? layout))
+        (is (doubly-additive? layout)))
+      (testing "with the object vectors pointing up and the attribute vectors down,
+                which is what makes the diagram respect the order by construction"
+        (let [pos (lay/positions layout)]
+          (doseq [[a b] (lay/connections layout)]
+            (is (< (second (pos a)) (second (pos b))))))))))
 
 (deftest test-dim-flux-layout-rejects-other-arguments
   (is (thrown? IllegalArgumentException (dim-flux-layout 42)))

--- a/src/test/clojure/conexp/layouts/dim_flux_test.clj
+++ b/src/test/clojure/conexp/layouts/dim_flux_test.clj
@@ -168,6 +168,20 @@
       (is (line-diagram? layout))
       (is (doubly-additive? layout)))))
 
+(deftest test-dim-flux-layout-initial
+  (testing "every starting diagram yields a valid additive line diagram"
+    (doseq [ctx      all-contexts
+            initial  [:dim-draw :greedy :layered simple-layered-layout]]
+      (let [layout (dim-flux-layout ctx {:initial initial})]
+        (is (line-diagram? layout)
+            (str "line diagram for " initial))
+        (is (doubly-additive? layout)
+            (str "additive for " initial))
+        (is (= (edges-of (concept-lattice ctx)) (set (lay/connections layout)))))))
+  (testing "an unknown starting diagram is rejected"
+    (is (thrown? IllegalArgumentException
+                 (dim-flux-layout dwarf-planets {:initial :nonsense})))))
+
 (deftest test-dim-flux-layout-rejects-other-arguments
   (is (thrown? IllegalArgumentException (dim-flux-layout 42)))
   (is (thrown? IllegalArgumentException


### PR DESCRIPTION
DimFlux gets slow past roughly 30 concepts. This makes it usable well beyond that, with two commits: an exact speedup of the force model, and a choice of starting diagram including the alternative the paper itself offers.

## Where the time goes

Profiling first. The force model was never the bottleneck: the exact two-dimension extension of DimDraw is. On random contexts it needs about a second at 16 concepts and half a minute at 23, while the projection stays in single milliseconds.

## 1. Exact speedup of the forces

The forces now visit only the elements that can move the conflict distance at all. For a node and a non-incident edge, an object matters exactly if it lies below the upper end of the edge but not below the node, or below the node but not below the lower end; dually for an attribute. Everything else contributes exactly zero.

Both sets are intersections of words of the membership relation, which is now kept as bit sets, so the inner loop runs over a handful of elements instead of all of them. Evaluating the energy and its gradient gets **three to four and a half times faster**, the more so the larger the lattice.

This is not an approximation. Energies and gradients still agree with the reference implementation of the paper to machine precision, checked again after the rewrite.

## 2. A choice of starting diagram

The new `:initial` parameter picks the diagram the refinement starts from:

```clojure
(dim-flux-layout ctx {:initial :dim-draw})            ;; the algorithm of the paper, default
(dim-flux-layout ctx {:initial :greedy})              ;; greedy two-dimension extension
(dim-flux-layout ctx {:initial :planarity-enhancer})  ;; the paper's own alternative
(dim-flux-layout ctx {:initial :layered})             ;; no DimDraw at all
(dim-flux-layout ctx {:initial inf-additive-layout})  ;; any layout function
```

`:planarity-enhancer` implements the alternative described in the paper, the planarity enhancer of C. Zschalig extended to the doubly-additive representation, also exposed on its own as `planarity-enhancer-layout`. Its cost is quadratic in the number of irreducible elements rather than in the number of concepts, so it stays near a tenth of a second even on a lattice of a hundred elements. The diagram it produces is a valid line diagram by construction, because all object vectors point up and all attribute vectors down.

Its sup-inf distance is computed order-theoretically rather than through closures: the closure of a union of extents is the extent of the join and dually for intents, so all four quantities reduce to counts of irreducibles below the meet and above the join. The values agree exactly with the formula of the reference implementation, verified on three lattices.

## Measurements

Random contexts. Time for the whole algorithm, then the smallest distance between a node and a non-incident edge after scaling each diagram to unit height.

| concepts | `:dim-draw` | `:greedy` | `:planarity-enhancer` | `:layered` |
| --- | --- | --- | --- | --- |
| 16 | 1.1 s | 0.06 s | 0.08 s | 0.05 s |
| 23 | 32 s | 0.13 s | 0.10 s | 0.05 s |
| 36 | not run | 0.8 s | 0.3 s | 0.4 s |
| 70 | not run | 7 s | 0.4 s | 20 s |
| 108 | not run | 35 s | 51 s | 2 s |

| concepts | `:dim-draw` | `:greedy` | `:planarity-enhancer` | `:layered` |
| --- | --- | --- | --- | --- |
| 16 | 0.0813 | 0.0184 | 0.0582 | 0.0239 |
| 23 | 0.0263 | 0.0129 | 0.0195 | 0.0000 |
| 36 | not run | 0.0008 | 0.0076 | 0.0001 |
| 70 | not run | 0.0002 | 0.0001 | 0.0000 |
| 108 | not run | 0.0001 | 0.0007 | 0.0000 |

Up to roughly 25 concepts `:dim-draw` still gives the best diagram and is worth its price. Past that the planarity enhancer gives the best of the remaining three and is usually also the fastest.

Where the enhancer is used the time is no longer in the initial diagram at all. Of the 51 seconds at 108 concepts, the enhancer accounts for 0.1 and the projection for 0.3; the rest is the refinement running to its iteration cap. That cap has sharply diminishing returns, so 100 to 250 iterations buy nearly all the improvement there is. `doc/DimFlux.org` carries the full sweep.

## Compatibility

Defaults are unchanged, so `dim-flux-layout` still runs the algorithm exactly as published unless a parameter asks for something else. The default of 1000 iterations is kept for the same reason; below about 30 concepts the refinement converges long before it, so it costs nothing there.

Full suite passes: 585 tests, 7653 assertions, including new tests covering every starting mode and the planarity enhancer on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PURHiEwvBNn1EsXfgN9xBa