### PR TITLE
Update CITATION.cff for the 3.1.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,7 @@ authors:
     affiliation: University of Hildesheim
     email: tom.hanika@uni-hildesheim.de
     orcid: 'https://orcid.org/0000-0002-4918-6374'
-repository-code: 'https://github.com/fcatools/conexp-clj'
+repository-code: 'https://github.com/tomhanika/conexp-clj'
 abstract: >-
   This is conexp-clj, a general purpose software tool for
   Formal Concept Analysis. Its main purpose is to enable
@@ -56,5 +56,6 @@ preferred-citation:
     - family-names: Hirth
       given-names: Johannes
 license: EPL-1.0
-commit: 5254a10eab6759a7d0c60228892952de93f2aa58
-date-released: '2023-07-17'
+version: 3.1.0
+commit: daafba3227116edec7f88bd2b7e786a83f91a902
+date-released: '2026-09-05'


### PR DESCRIPTION
Brings the citation metadata in line with the 3.1.0 release. Cherry-picked from `dev` so that `master` carries it without the 3.2.0-SNAPSHOT bump, since GitHub reads `CITATION.cff` from the default branch for the "Cite this repository" panel.

Two things change.

**The release fields now describe 3.1.0.** `commit` and `date-released` had stood at a commit from July 2023 and were not touched through the four releases since, so anyone citing conexp-clj was citing a two year old state of it. A `version` field is added; the file carried none.

**`repository-code` named a fork.** It pointed at `fcatools/conexp-clj`, which the GitHub API confirms is a fork of this repository, last pushed in September 2024 and now two years behind. Citation metadata that sends readers to a stale fork of the software rather than the software is simply wrong, so it now names `tomhanika/conexp-clj`, matching `:url` and `:scm` in project.clj.

The author list and the preferred citation are untouched. Who is named there is a decision, not a mechanical consequence of cutting a release, and `AUTHORS.md` lists a good many contributors that `CITATION.cff` does not. Worth a separate look if you want the two to agree.

The tag `v3.1.0` stays where it is, on the release merge commit, so this lands as an ordinary commit after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PURHiEwvBNn1EsXfgN9xBa