### PR TITLE
Fix two flaky tests and the bugs behind them

### DIFF
--- a/src/main/clojure/conexp/fca/applications/networks/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/networks/socialanalytics.clj
@@ -115,7 +115,7 @@
                                                       (mapcat
                                                         #(vals (dissoc (breadth-first-search graph %) %))
                                                         (keys graph)))]
-    (if (= 0 amount-of-paths)
+    (if (zero? amount-of-paths)
       nil
       (/ sum-of-path-lengths amount-of-paths))))
 
@@ -468,10 +468,15 @@
           map-max (apply max (vals centrality))
           map-min (apply min (vals centrality))
           diff (- map-max map-min)]
-      (cond (= 0 map-max)
+      ;; `zero?` and not `(= 0 ...)`: the centralities are doubles, and `=`
+      ;; holds between numbers of different categories only if both are
+      ;; exact, so `(= 0 0.0)` is false.  Missing these two cases divides by
+      ;; zero, which is how a graph whose nodes all have the same centrality
+      ;; used to come out as NaN.
+      (cond (zero? map-max)
             centrality
             ;;;
-            (= 0 diff)
+            (zero? diff)
             (zipmap (keys centrality) (repeat 0))
             ;;;
             :else

--- a/src/main/clojure/conexp/fca/applications/networks/socialanalytics.clj
+++ b/src/main/clojure/conexp/fca/applications/networks/socialanalytics.clj
@@ -115,6 +115,8 @@
                                                       (mapcat
                                                         #(vals (dissoc (breadth-first-search graph %) %))
                                                         (keys graph)))]
+    ;; always exact, being counted up from 0, so this one was never at risk of
+    ;; the mixed-category comparison that broke the normalisation below
     (if (zero? amount-of-paths)
       nil
       (/ sum-of-path-lengths amount-of-paths))))

--- a/src/main/clojure/conexp/sigmajs/base.clj
+++ b/src/main/clojure/conexp/sigmajs/base.clj
@@ -29,10 +29,13 @@
     }"))]
      (str
        "{\n  \"nodes\": [\n"
-       (if nodes (node->str (first nodes)))
+       ;; `seq` and not the collection itself: an empty set and an empty
+       ;; sequence are both truthy, so the plain test emitted a node with no
+       ;; identifier for a graph without nodes and threw on one without edges.
+       (when (seq nodes) (node->str (first nodes)))
        (apply str (map #(str ",\n" (node->str %)) (drop 1 nodes)))
        "\n  ],\n  \"edges\": [\n"
-       (if edges (edge->str (first edges) 0))
+       (when (seq edges) (edge->str (first edges) 0))
        (apply str (map (fn [e id] (str ",\n" (edge->str e id))) 
                        (drop 1 edges)
                        (drop 1(range (count edges)))))

--- a/src/test/clojure/conexp/fca/applications/networks/socialanalytics_test.clj
+++ b/src/test/clojure/conexp/fca/applications/networks/socialanalytics_test.clj
@@ -599,6 +599,21 @@
       (every? #(= (atr-centrality %) (centrality %))
               (keys (attribute-projection ctx))))))
 
+(defn- normalized-centrality?
+  "A normalised betweenness centrality is either empty, constant, or spread so
+  that its largest value is 1 and its smallest 0.
+
+  The comparisons are numeric: the centralities are doubles, and `=` holds
+  between numbers of different categories only if both are exact, so `(= 0 0.0)`
+  is false and a constant map of doubles would otherwise look like a violation."
+  [hmap]
+  (let [vs (vals hmap)]
+    (or (empty? hmap)
+        (every? #(== 0 %) vs)
+        (every? #(== 1 %) vs)
+        (and (near? 1.0 (apply max vs))
+             (near? 0.0 (apply min vs))))))
+
 (deftest test-context-graph-betweenes-centrality-normalized
   (let [centrality-ctx (context-graph-betweenes-centrality-normalized
                          (make-context-from-matrix 5 4
@@ -623,12 +638,8 @@
     (is (every? #(near? (centrality-ctx1 %) (solution-ctx1 %) 0.01)
                (keys centrality-ctx1))))
   (with-testing-data [ctx (random-contexts 20 20)]
-                     (let [hmap (context-graph-betweenes-centrality-normalized ctx)]
-                       (or (empty? hmap)
-                           (= #{0} (set (vals hmap)))
-                           (= #{1} (set (vals hmap)))
-                           (and (near? 1.0 (apply max (vals hmap)))
-                                (near? 0.0 (apply min (vals hmap))))))))
+                     (normalized-centrality?
+                      (context-graph-betweenes-centrality-normalized ctx))))
 
 (deftest test-object-projection-betweenes-centrality-normalized
   (let [ctx (make-context-from-matrix 5 4 [1 0 0 0
@@ -641,15 +652,11 @@
                                                     [1 0 0
                                                      1 1 0
                                                      0 1 1]))]
-    (is (= #{0} (set (vals (object-projection-betweenes-centrality-normalized ctx)))))
+    (is (every? #(== 0 %) (vals (object-projection-betweenes-centrality-normalized ctx))))
     (is (= centrality-ctx1 {'a 0.0 'b 1.0 'c 0.0})))
   (with-testing-data [ctx (random-contexts 20 20)]
-                     (let [hmap (object-projection-betweenes-centrality-normalized ctx)]
-                       (or (empty? hmap)
-                           (= 0 (apply max (vals hmap)))
-                           (= 1 (apply min (vals hmap)))
-                           (and (near? 1.0 (apply max (vals hmap)))
-                                (near? 0.0 (apply min (vals hmap))))))))
+                     (normalized-centrality?
+                      (object-projection-betweenes-centrality-normalized ctx))))
 
 (deftest test-attribute-projection-betweenes-centrality-normalized
   (let [ctx (make-context-from-matrix 5 4 [1 0 0 0
@@ -662,15 +669,11 @@
                                                     [1 0 0
                                                      1 1 0
                                                      0 1 1]))]
-    (is (= #{0} (set (vals (attribute-projection-betweenes-centrality-normalized ctx)))))
+    (is (every? #(== 0 %) (vals (attribute-projection-betweenes-centrality-normalized ctx))))
     (is (= centrality-ctx1 {2 0.0 4 1.0 6 0.0})))
   (with-testing-data [ctx (random-contexts 20 20)]
-                     (let [hmap (attribute-projection-betweenes-centrality-normalized ctx)]
-                       (or (empty? hmap)
-                           (= 0 (apply max (vals hmap)))
-                           (= 1 (apply min (vals hmap)))
-                           (and (near? 1.0 (apply max (vals hmap)))
-                                (near? 0.0 (apply min (vals hmap))))))))
+                     (normalized-centrality?
+                      (attribute-projection-betweenes-centrality-normalized ctx))))
 
 
 ;;;

--- a/src/test/clojure/conexp/layouts/freese_test.clj
+++ b/src/test/clojure/conexp/layouts/freese_test.clj
@@ -17,9 +17,16 @@
 ;;;
 
 (deftest test-freese
-  (let [lat (concept-lattice (rand-context 10 10 0.5))]
-    (is (layout? (freese-layout lat)))
-    (is (layout? ((interactive-freese-layout lat) 0.0))))
+  ;; The context is held and named in the assertion messages.  This test draws a
+  ;; random lattice, and has been seen to fail about once in twenty-five runs of
+  ;; the suite while never failing in two thousand runs on its own, so the input
+  ;; is the one thing needed to chase it and the one thing a bare failure did
+  ;; not report.
+  (let [ctx (rand-context 10 10 0.5)
+        lat (concept-lattice ctx)
+        ctx-msg (str "context: " (pr-str ctx))]
+    (is (layout? (freese-layout lat)) ctx-msg)
+    (is (layout? ((interactive-freese-layout lat) 0.0)) ctx-msg))
   (let [poset (make-poset [1 2 3 4 5 6]
                         (fn [A B] 
                           (contains? #{[1 1] [1 2] [1 3] [1 5] [1 6]

--- a/src/test/clojure/conexp/sigmajs/base_test.clj
+++ b/src/test/clojure/conexp/sigmajs/base_test.clj
@@ -1,48 +1,69 @@
+;; Copyright ⓒ the conexp-clj developers; all rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file LICENSE at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
 (ns conexp.sigmajs.base-test
-  (:require [loom.graph :as lg])
+  "Tests for the sigma.js serialization.
+
+  The output is checked by parsing it rather than by matching it against a
+  regular expression.  The old regular expression pinned the node order and
+  required every coordinate to look like `[0-9.]+`, but `graph->json` places
+  nodes at `(rand)` by default, and Java prints a double below 0.001 in
+  scientific notation, as in `9.25937777300545E-4`.  That made the test fail on
+  0.6% of runs, measured over 20000 builds."
+  (:require [clojure.data.json :as json]
+            [loom.graph :as lg])
   (:use clojure.test
         conexp.sigmajs.base))
 
-(deftest test-graph->json
-  (is
-    (let [g (lg/digraph [:a :b] [:b :c])]
-      (.matches (graph->json g) " *\\{
-? *\"nodes\": *\\[
-? *\\{
-? *\"id\": *\":c\",(
-? *\"label\": *\":c\",)?
-? *\"x\": *\"?[0-9.]+\"?,
-? *\"y\": *\"?[0-9.]+\"?(,
-? *\"size: *\"?[0-9.]+\"?)?
-? *\\},
-? *\\{
-? *\"id\": *\":b\",
-? *\"label\": *\":b\",
-? *\"x\": *\"?[0-9.]+\"?,
-? *\"y\": *\"?[0-9.]+\"?(,
-? *\"size: *\"?[0-9.]+\"?)?
-? *\\},
-? *\\{
-? *\"id\": *\":a\",
-? *\"label\": *\":a\",
-? *\"x\": *\"?[0-9.]+\"?,
-? *\"y\": *\"?[0-9.]+\"?(,
-? *\"size: *\"?[0-9.]+\"?)?
-? *\\}
-? *\\],
-? *\"edges\": *\\[
-? *\\{
-? *\"id\": *\".*\",
-? *\"source\": *\":b\",
-? *\"target\": *\":c\"
-? *\\},
-? *\\{
-? *\"id\": *\".*\",
-? *\"source\": *\":a\",
-? *\"target\": *\":b\"
-? *\\}
-? *\\]
-? *\\}"))))
+(def ^:private test-graph (lg/digraph [:a :b] [:b :c]))
+
+(deftest test-graph->json-is-valid-json
+  (let [parsed (json/read-str (graph->json test-graph))]
+    (is (= #{"nodes" "edges"} (set (keys parsed))))))
+
+(deftest test-graph->json-nodes
+  (let [nodes (get (json/read-str (graph->json test-graph)) "nodes")]
+    (testing "one entry per node of the graph, labelled by itself"
+      (is (= #{":a" ":b" ":c"} (set (map #(get % "id") nodes))))
+      (is (every? #(= (get % "id") (get % "label")) nodes)))
+    (testing "every node is placed somewhere"
+      (is (every? #(and (number? (get % "x")) (number? (get % "y"))) nodes)))))
+
+(deftest test-graph->json-edges
+  (let [edges (get (json/read-str (graph->json test-graph)) "edges")]
+    (testing "one entry per edge, joining the nodes the graph joins"
+      (is (= #{[":a" ":b"] [":b" ":c"]}
+             (set (map (juxt #(get % "source") #(get % "target")) edges)))))
+    (testing "the ids distinguish the edges"
+      (is (= (count edges) (count (distinct (map #(get % "id") edges))))))))
+
+(deftest test-graph->json-uses-the-given-positions
+  (testing "positions come from the supplied function, which is what makes a
+            drawn layout serializable"
+    (let [nodes (-> (graph->json test-graph (fn [n] [(count (name n)) 7]))
+                    json/read-str
+                    (get "nodes"))]
+      (is (every? #(= 7 (get % "y")) nodes))
+      (is (every? #(= (count (subs (get % "id") 1)) (get % "x")) nodes)))))
+
+(deftest test-graph->json-survives-small-coordinates
+  (testing "a coordinate small enough that Java prints it in scientific
+            notation still has to parse back as the number it was"
+    (let [parsed (-> (graph->json test-graph (fn [_] [9.25937777300545E-4 1.0E-7]))
+                     json/read-str
+                     (get "nodes"))]
+      (is (every? #(= 9.25937777300545E-4 (get % "x")) parsed))
+      (is (every? #(= 1.0E-7 (get % "y")) parsed)))))
+
+(deftest test-graph->json-empty-graph
+  (let [parsed (json/read-str (graph->json (lg/digraph)))]
+    (is (empty? (get parsed "nodes")))
+    (is (empty? (get parsed "edges")))))
 
 ;;;
 

--- a/src/test/clojure/conexp/sigmajs/base_test.clj
+++ b/src/test/clojure/conexp/sigmajs/base_test.clj
@@ -65,6 +65,13 @@
     (is (empty? (get parsed "nodes")))
     (is (empty? (get parsed "edges")))))
 
+(deftest test-graph->json-graph-without-edges
+  (testing "a graph of isolated nodes, which is the case the old guards broke on
+            in practice: they threw rather than writing an empty edge list"
+    (let [parsed (json/read-str (graph->json (lg/add-nodes (lg/digraph) :a :b :c)))]
+      (is (= #{":a" ":b" ":c"} (set (map #(get % "id") (get parsed "nodes")))))
+      (is (empty? (get parsed "edges"))))))
+
 ;;;
 
 nil


### PR DESCRIPTION
CI failed on #189, a pull request that changed nothing but a YAML file. That is not something a citation file can cause, so I ran the suite twenty-five times to find out what is actually unstable. Three tests are. Two had real bugs behind them; one is still unexplained.

Roughly a one-in-ten chance that any CI run failed for reasons unrelated to the change under test, which matches what happened across #185 to #189.

## `test-graph->json` — 0.61% of builds, cause proven

`graph->json` places nodes at `(rand)` by default, and Java prints a double below 0.001 in scientific notation, for example `9.25937777300545E-4`. The test matched coordinates against `[0-9.]+`, which has no `E`. Measured directly over 20000 builds: 121 failures, 0.61%.

The test now parses the JSON instead of matching it with a regular expression, and checks the nodes, the edges, the supplied position function, small coordinates and the empty graph separately. Over 30000 builds after the change: zero failures.

**Writing that test found a second bug.** In Clojure an empty set and an empty sequence are both truthy, so the `(if nodes ...)` and `(if edges ...)` guards in `graph->json` never fired. A graph with no edges threw `No implementation of method: :src of protocol: Edge found for class: nil`, and a graph with no nodes emitted a node with an empty identifier. Both now test with `seq`.

## `test-context-graph-betweenes-centrality-normalized` — 1 run in 11, cause proven

One root cause with two faces: `=` between numbers of different categories. `(= 0 0.0)` is **false**, since `=` holds across categories only when both are exact.

- In `betweenes-centrality-normalized` the guards `(= 0 map-max)` and `(= 0 diff)` therefore missed a zero spread of double centralities, and the function divided by it. A graph whose nodes all have the same centrality came out as NaN, or crashed with `ArithmeticException: Divide by zero` when the values happened to be exact. I hit that crash while hunting a counterexample.
- The test made the same mistake in the other direction, asserting `(= #{0} (set (vals hmap)))` against a set of doubles, so a correct constant result looked like a violation.

The guards now use `zero?`, which is type-agnostic, and the property is stated once as a named predicate comparing numerically. Over 4000 random contexts after the change: no crashes, no NaN, no violations. Before the change the same loop crashed.

The same `(= 0 ...)` pattern in `context-graph-average-shortest-path-via-bfs` is fixed too.

## `test-freese` — 1 run in 25, not explained

This one I could not solve, and I would rather say so than guess.

It failed once in twenty-five suite runs, producing four errors at once, all inside latdraw's `Diagram` constructor, including on the fixed six-element poset that is deterministic input. It did not fail once in 2000 runs on its own, on lattices of 23 to 110 concepts, with or without the headless profile. Four simultaneous errors on deterministic input point at something environmental rather than input-driven. I ruled out shared mutable state in latdraw, whose only mutable static is used solely in serialisation, and the heap, which does get the intended `-Xmx4G`.

Since the input is the one thing a failure did not report and the one thing needed to chase it, the test now names its context in the assertion messages. The next occurrence will be reproducible.

## Verification

Ten full suite runs after the changes, no failures. 597 tests, no failures locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PURHiEwvBNn1EsXfgN9xBa