### PR TITLE
Make java -jar conexp-clj.jar -l file.clj work

### DIFF
--- a/src/main/clojure/conexp/main.clj
+++ b/src/main/clojure/conexp/main.clj
@@ -49,6 +49,20 @@
    ["-d" "--dev" "Start the api with hot code reload"]
    ["-h" "--help" "This help"]])
 
+(defn- load-conexp-file
+  "Loads the given file with the conexp-clj namespaces in scope.
+
+  `binding` and not `in-ns`: every other branch of `-main` runs its `in-ns`
+  inside a REPL, which holds a thread binding for `*ns*`, but this one runs
+  straight out of `-main`.  An AOT compiled uberjar has no such binding, and
+  `in-ns` then dies with \"Can't change/establish root binding of: *ns*\", which
+  is why `java -jar conexp-clj.jar -l file.clj` never worked.  Binding it also
+  confines the change to this call, so a loaded file cannot leave the process
+  sitting in another namespace."
+  [file]
+  (binding [*ns* (find-ns 'conexp.main)]
+    (load-file file)))
+
 (defn -main [& args]
   (let [{:keys [options summary errors]}
         (cli/parse-opts args conexp-clj-options)]
@@ -78,9 +92,7 @@
         :custom-help ""})
       ;;
       (contains? options :load)
-      (do
-        (in-ns 'conexp.main)
-        (load-file (options :load)))
+      (load-conexp-file (options :load))
       ;;
       (contains? options :api)
       (reply/launch

--- a/src/test/clojure/conexp/main_test.clj
+++ b/src/test/clojure/conexp/main_test.clj
@@ -1,0 +1,62 @@
+;; Copyright ⓒ the conexp-clj developers; all rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file LICENSE at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns conexp.main-test
+  (:require [clojure.test :refer :all]
+            [conexp.main]))
+
+(def ^:private load-conexp-file
+  ;; `-main` itself ends in `System/exit`, so the load path is exercised through
+  ;; the function `-main` delegates to.
+  @#'conexp.main/load-conexp-file)
+
+(defn- on-a-bare-thread
+  "Runs `f` on a fresh thread and returns whatever it threw, or nil.
+
+  A plain thread carries no thread bindings, which is exactly the situation
+  `-main` finds itself in when it is the entry point of an AOT compiled uberjar
+  rather than something a REPL called.  Running this on the calling thread would
+  not reproduce it, because the test runner does hold a binding for `*ns*`."
+  [f]
+  (let [thrown (atom nil)
+        thread (Thread. #(try (f) (catch Throwable t (reset! thrown t))))]
+    (.start thread)
+    (.join thread 60000)
+    @thrown))
+
+(deftest test-load-option-without-a-namespace-binding
+  (let [file (java.io.File/createTempFile "conexp-load" ".clj")]
+    (try
+      (spit file "(def loaded-context (make-context #{1 2} #{'a} #{[1 'a]}))\n")
+      (testing "`-l` has to work with no thread binding for `*ns*`, which is how
+                it is reached from `java -jar`"
+        (let [thrown (on-a-bare-thread #(load-conexp-file (.getAbsolutePath file)))]
+          (is (nil? thrown)
+              (str "loading threw " (some-> thrown class .getName) ": "
+                   (some-> thrown .getMessage)))))
+      (testing "and the file is evaluated where conexp is in scope, so it may use
+                the library without requiring anything"
+        (is (some? (resolve 'conexp.main/loaded-context))))
+      (finally
+        (ns-unmap 'conexp.main 'loaded-context)
+        (.delete file)))))
+
+(deftest test-load-option-leaves-the-namespace-alone
+  (let [file (java.io.File/createTempFile "conexp-load" ".clj")
+        before *ns*]
+    (try
+      (spit file "(def untouched 1)\n")
+      (load-conexp-file (.getAbsolutePath file))
+      (is (= before *ns*) "loading a file must not move the caller's namespace")
+      (finally
+        (ns-unmap 'conexp.main 'untouched)
+        (.delete file)))))
+
+;;;
+
+nil


### PR DESCRIPTION
Found while building the standalone jar for the 3.1.0 release: loading a file from that jar crashes.

```
$ java -jar conexp-clj-3.1.0-standalone-openjdk-21.jar -l script.clj
Exception in thread "main" java.lang.IllegalStateException:
  Can't change/establish root binding of: *ns* with set
        at conexp.main$_main.invokeStatic(main.clj:82)
```

## Cause

The `--load` branch of `-main` calls `in-ns` directly. Every other branch runs its `in-ns` inside `reply/launch`, that is inside a REPL, which holds a thread binding for `*ns*`. This one runs straight out of `-main`, and an AOT compiled uberjar has no such binding there, so the `set!` behind `in-ns` has nothing to set.

Under `lein run` it works, because clojure.main establishes the binding before calling `-main`. That is why it was never noticed: the option is only broken in exactly the artifact most users take. It dates back to the REST API pull request, so every standalone jar released so far has it, not just 3.1.0.

## Fix

The load path binds `*ns*` rather than mutating it. That fixes the crash and also confines the change to the one call, so a loaded file can no longer leave the process sitting in another namespace.

It moves into its own function because `-main` ends in `(System/exit 0)` and therefore cannot be called from a test at all.

## Test

The test drives the load on a bare thread. A plain thread carries no thread bindings, which is precisely the situation an uberjar entry point is in; running it on the calling thread would prove nothing, since the test runner holds a binding for `*ns*`.

I checked the test actually catches the bug rather than merely passing: reverting the fix turns it red with the original `Can't change/establish root binding of: *ns*`, and restoring it turns it green.

Verified end to end as well. A freshly built uberjar now runs

```
$ java -jar conexp-clj-3.2.0-SNAPSHOT-standalone.jar -l load-check.clj
loaded file ran in namespace: conexp.main
concepts: 4
dimflux nodes: 4
```

Full suite: 600 tests, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PURHiEwvBNn1EsXfgN9xBa