### PR TITLE
Silence the remaining javac warnings, and fix a modifier-click bug

### DIFF
--- a/src/main/java/no/geosoft/cc/graphics/GCanvas.java
+++ b/src/main/java/no/geosoft/cc/graphics/GCanvas.java
@@ -603,17 +603,61 @@ public class GCanvas extends JComponent
    * 
    * @param event  Mouse event trigging this method.
    */
+  /**
+   * Maps the button of a press or release event to one of the given
+   * GWindow constants.
+   * <p>
+   * Uses <tt>getButton</tt> rather than the deprecated <tt>getModifiers</tt>.
+   * Besides the deprecation, the old code compared the whole modifier mask for
+   * equality with <tt>BUTTON1_MASK</tt>, so a click with any modifier held --
+   * shift-click, for instance -- matched neither button 1 nor button 2 and was
+   * reported as button 3.
+   *
+   * @param event    the press or release event.
+   * @param button1  constant to return for the first button.
+   * @param button2  constant to return for the second button.
+   * @param button3  constant to return for anything else.
+   * @return  one of the three constants.
+   */
+  static int buttonEventOf (MouseEvent event, int button1, int button2,
+                            int button3)
+  {
+    switch (event.getButton()) {
+      case MouseEvent.BUTTON1 : return button1;
+      case MouseEvent.BUTTON2 : return button2;
+      default                 : return button3;
+    }
+  }
+
+
+
+  /**
+   * Maps the button held during a drag to one of the given GWindow constants.
+   * <p>
+   * A drag event reports no button through <tt>getButton</tt>, so the buttons
+   * currently held are read from the extended modifiers instead.
+   *
+   * @param event    the drag event.
+   * @param button1  constant to return while the first button is held.
+   * @param button2  constant to return while the second button is held.
+   * @param button3  constant to return otherwise.
+   * @return  one of the three constants.
+   */
+  static int draggedButtonEventOf (MouseEvent event, int button1, int button2,
+                                   int button3)
+  {
+    int modifiers = event.getModifiersEx();
+    if ((modifiers & MouseEvent.BUTTON1_DOWN_MASK) != 0) return button1;
+    if ((modifiers & MouseEvent.BUTTON2_DOWN_MASK) != 0) return button2;
+    return button3;
+  }
+
+
+
   public void mousePressed (MouseEvent event)
   {
-    int modifiers = event.getModifiers();
-    int buttonEvent;
-
-    if      (modifiers == event.BUTTON1_MASK)
-      buttonEvent = GWindow.BUTTON1_DOWN;
-    else if (modifiers == event.BUTTON2_MASK)
-      buttonEvent = GWindow.BUTTON2_DOWN;
-    else
-      buttonEvent = GWindow.BUTTON3_DOWN;
+    int buttonEvent = buttonEventOf (event, GWindow.BUTTON1_DOWN,
+                                     GWindow.BUTTON2_DOWN, GWindow.BUTTON3_DOWN);
 
     window_.mousePressed (buttonEvent, event.getX(), event.getY());
   }
@@ -628,15 +672,8 @@ public class GCanvas extends JComponent
    */
   public void mouseReleased (MouseEvent event)
   {
-    int modifiers = event.getModifiers();
-    int buttonEvent;
-
-    if      (modifiers == event.BUTTON1_MASK)
-      buttonEvent = GWindow.BUTTON1_UP;
-    else if (modifiers == event.BUTTON2_MASK)
-      buttonEvent = GWindow.BUTTON2_UP;
-    else
-      buttonEvent = GWindow.BUTTON3_UP;
+    int buttonEvent = buttonEventOf (event, GWindow.BUTTON1_UP,
+                                     GWindow.BUTTON2_UP, GWindow.BUTTON3_UP);
 
     window_.mouseReleased (buttonEvent, event.getX(), event.getY());
   }
@@ -652,15 +689,9 @@ public class GCanvas extends JComponent
    */
   public void mouseDragged (MouseEvent event)
   {
-    int modifiers = event.getModifiers();
-    int buttonEvent;
-
-    if      (modifiers == event.BUTTON1_MASK)
-      buttonEvent = GWindow.BUTTON1_DRAG;
-    else if (modifiers == event.BUTTON2_MASK)
-      buttonEvent = GWindow.BUTTON2_DRAG;
-    else
-      buttonEvent = GWindow.BUTTON3_DRAG;
+    int buttonEvent = draggedButtonEventOf (event, GWindow.BUTTON1_DRAG,
+                                            GWindow.BUTTON2_DRAG,
+                                            GWindow.BUTTON3_DRAG);
 
     window_.mouseDragged (buttonEvent, event.getX(), event.getY());
   }

--- a/src/main/java/no/geosoft/cc/graphics/GObject.java
+++ b/src/main/java/no/geosoft/cc/graphics/GObject.java
@@ -71,10 +71,10 @@ public class GObject
   private boolean     isRegionValid_;  // Has it been computed?
   private GObject     parent_;         // Immediate ancestor
   private int         visibilityMask_;    
-  private List        children_;       // of GObject
+  private List<GObject>   children_;       // of GObject
   private GStyle      style_;          // As specified by application
   private GStyle      actualStyle_;    // Adjusted for inherits
-  private List        segments_;       // of GSegment
+  private List<GSegment>  segments_;       // of GSegment
   private boolean     isDrawn_;
   private Object      userData_;       // Application defined
   
@@ -91,7 +91,7 @@ public class GObject
     name_           = name;
     parent_         = null;
     region_         = new Region();
-    children_       = new ArrayList();
+    children_       = new ArrayList<>();
     isRegionValid_  = true;
     segments_       = null;
     visibilityMask_ = VISIBLE;
@@ -697,9 +697,9 @@ public class GObject
    * @return    List of segments intersecting the rectangle.
    *            If none do, an empty list is returned.
    */
-  public List findSegments (int x0, int y0, int x1, int y1)
+  public List<GSegment> findSegments (int x0, int y0, int x1, int y1)
   {
-    List segments = new ArrayList();
+    List<GSegment> segments = new ArrayList<>();
     findSegments (x0, y0, x1, y1, segments);
     return segments;
   }
@@ -717,9 +717,9 @@ public class GObject
    * @return    List of segments intersecting the rectangle.
    *            If none do, an empty list is returned.
    */
-  public List findSegmentsInside (int x0, int y0, int x1, int y1)
+  public List<GSegment> findSegmentsInside (int x0, int y0, int x1, int y1)
   {
-    List segments = new ArrayList();
+    List<GSegment> segments = new ArrayList<>();
     findSegmentsInside (x0, y0, x1, y1, segments);
     return segments;
   }
@@ -740,7 +740,7 @@ public class GObject
   public GSegment findSegment (int x0, int y0, int x1, int y1)
   {
     // Tailormake to stop after first found
-    List segments = findSegments (x0, y0, x1, y1);
+    List<GSegment> segments = findSegments (x0, y0, x1, y1);
     return segments.size() == 0 ? null :
                      (GSegment) segments.get (segments.size() - 1);
     
@@ -762,7 +762,7 @@ public class GObject
   public GSegment findSegmentInside (int x0, int y0, int x1, int y1)
   {
     // TODO: Stop after first found
-    List segments = findSegmentsInside (x0, y0, x1, y1);
+    List<GSegment> segments = findSegmentsInside (x0, y0, x1, y1);
     return segments.size() == 0 ? null :
                      (GSegment) segments.get (segments.size() - 1);
   }
@@ -779,7 +779,7 @@ public class GObject
    */
   public GSegment findSegment (int x, int y)
   {
-    List segments = findSegments (x, y);
+    List<GSegment> segments = findSegments (x, y);
     return segments.size() == 0 ? null :
                      (GSegment) segments.get (segments.size() - 1);
   }
@@ -794,9 +794,9 @@ public class GObject
    * @return      All segments intersecting the point.  If none do, an
    *              empty list is returned.
    */
-  public List findSegments (int x, int y)
+  public List<GSegment> findSegments (int x, int y)
   {
-    List segments = new ArrayList();
+    List<GSegment> segments = new ArrayList<>();
     findSegments (x, y, segments);
     return segments;
   }
@@ -813,7 +813,8 @@ public class GObject
    * @param y1        Y coordinate of lower right corner of rectangle.
    * @param segments  List to add segments to.
    */
-  private void findSegments (int x0, int y0, int x1, int y1, List segments)
+  private void findSegments (int x0, int y0, int x1, int y1,
+                             List<GSegment> segments)
   {
     // Don't scan any furher if the region doesn't intersect
     if (!region_.isIntersecting (new Rect (x0, y0, x1-x0+1, y1-y0+1)))
@@ -845,7 +846,7 @@ public class GObject
    * @param y         Y coordinate of point to check.
    * @param segments  List to add segments to.
    */
-  private void findSegments (int x, int y, List segments)
+  private void findSegments (int x, int y, List<GSegment> segments)
   {
     // Don't scan any furher if the region doesn't intersect
     if (!region_.isInside (x, y))
@@ -880,7 +881,7 @@ public class GObject
    * @param segments  List to add segments to.
    */
   private void findSegmentsInside (int x0, int y0, int x1, int y1,
-                                   List segments)
+                                   List<GSegment> segments)
   {
     // Don't scan any furher if the region doesn't intersect
     if (!region_.isIntersecting (new Rect (x0, y0, x1-x0+1, y1-y0+1)))
@@ -917,7 +918,7 @@ public class GObject
   public GObject find (int x0, int y0, int x1, int y1)
   {
     // TODO: As it needs the first only, this can be optimized
-    List objects = findAll (x0, y0, x1, y1);
+    List<GObject> objects = findAll (x0, y0, x1, y1);
     return objects.size() == 0 ? null :
                      (GObject) objects.get (objects.size() - 1);
   }
@@ -937,7 +938,7 @@ public class GObject
   public GObject findInside (int x0, int y0, int x1, int y1)
   {
     // TODO: As it needs the first only, this can be optimized
-    List objects = findAllInside (x0, y0, x1, y1);
+    List<GObject> objects = findAllInside (x0, y0, x1, y1);
     return objects.size() == 0 ? null :
                      (GObject) objects.get (objects.size() - 1);
   }
@@ -971,9 +972,9 @@ public class GObject
    * @param y1  Y coordinate of lower right corner of rectangle.
    * @return    All objects intersecting the specified rectangle.
    */
-  public List findAll (int x0, int y0, int x1, int y1)
+  public List<GObject> findAll (int x0, int y0, int x1, int y1)
   {
-    List objects = new ArrayList();
+    List<GObject> objects = new ArrayList<>();
     findAll (x0, y0, x1, y1, objects);
     return objects;
   }
@@ -989,9 +990,9 @@ public class GObject
    * @param x0, y0, x1, y1  Rectangle to check.
    * @return                All objects intersecting the rectangle.
    */
-  public List findAllInside (int x0, int y0, int x1, int y1)
+  public List<GObject> findAllInside (int x0, int y0, int x1, int y1)
   {
-    List objects = new ArrayList();
+    List<GObject> objects = new ArrayList<>();
     findAllInside (x0, y0, x1, y1, objects);
     return objects;
   }
@@ -1008,7 +1009,7 @@ public class GObject
    * @param y  Y coordinate of point to check.   
    * @return   All objects intersecting the specfied point.
    */
-  public List findAll (int x, int y)
+  public List<GObject> findAll (int x, int y)
   {
     return findAll (x - 1, y - 1, x + 1, y + 1);
   }
@@ -1024,7 +1025,7 @@ public class GObject
    * @param y1       Y coordinate of lower right corner of rectangle.
    * @param objects  Object collection to add to.
    */
-  private void findAll (int x0, int y0, int x1, int y1, List objects)
+  private void findAll (int x0, int y0, int x1, int y1, List<GObject> objects)
   {
     // Don't scan any furher if the region doesn't intersect
     if (!region_.isIntersecting (new Rect (x0, y0, x1 - x0 + 1, y1 - y0 + 1)))
@@ -1059,7 +1060,7 @@ public class GObject
    * @param y1       Y coordinate of lower right corner of rectangle.
    * @param objects  Object collection to add to.
    */
-  private void findAllInside (int x0, int y0, int x1, int y1, List objects)
+  private void findAllInside (int x0, int y0, int x1, int y1, List<GObject> objects)
   {
     Box box = new Box (x0, y0, x1, y1);
     
@@ -1122,7 +1123,7 @@ public class GObject
   public void removeAll()
   {
     // Loop over a copy of the children list as they are removed
-    Collection children = new ArrayList (children_);
+    Collection<GObject> children = new ArrayList<> (children_);
     for (Iterator i = children.iterator(); i.hasNext(); ) {
       GObject child = (GObject) i.next();
       remove (child);
@@ -1228,7 +1229,7 @@ public class GObject
   {
     // Lazy create as not all GObjects will have segments
     if (segments_ == null)
-      segments_ = new ArrayList();
+      segments_ = new ArrayList<>();
 
     // Do nothing if it is there already
     if (segments_.contains (segment))

--- a/src/main/java/no/geosoft/cc/graphics/GSegment.java
+++ b/src/main/java/no/geosoft/cc/graphics/GSegment.java
@@ -77,9 +77,9 @@ public class GSegment
   private GStyle       style_;       // As applied to this object
   private GStyle       actualStyle_; // Adjusted for owner inherits
   private boolean      isVisible_;   // Due to position not vis. setting
-  private List         texts_;       // of GText
-  private Collection   components_;  // of GComponent
-  private Collection   images_;      // of GImage
+  private List<GText>       texts_;       // of GText
+  private Collection<GComponent> components_;  // of GComponent
+  private Collection<GImage>     images_;      // of GImage
 
 
   
@@ -795,7 +795,7 @@ public class GSegment
   {
     // Create if first text
     if (texts_ == null)
-      texts_ = new ArrayList();
+      texts_ = new ArrayList<>();
 
     // Add to list
     texts_.add (text);
@@ -876,7 +876,7 @@ public class GSegment
   {
     // Create if first time
     if (images_ == null)
-      images_ = new ArrayList();
+      images_ = new ArrayList<>();
 
     // Add to list
     images_.add (image);
@@ -967,7 +967,7 @@ public class GSegment
   {
     // Create if first time
     if (components_ == null)
-      components_ = new ArrayList();
+      components_ = new ArrayList<>();
 
     component.setSegment (this);
     

--- a/src/main/java/no/geosoft/cc/graphics/GStyle.java
+++ b/src/main/java/no/geosoft/cc/graphics/GStyle.java
@@ -93,7 +93,7 @@ public class GStyle
   public static final int   FILL_VERTICAL   = 7;
   public static final int   FILL_DIAGONAL   = 8;              
 
-  private final Collection     listeners_;
+  private final Collection<WeakReference<GStyleListener>> listeners_;
 
   private int            validMask_;
   private Color          foregroundColor_;
@@ -124,7 +124,7 @@ public class GStyle
    */
   public GStyle()
   {
-    listeners_       = new ArrayList();
+    listeners_       = new ArrayList<>();
     
     // Flag everything setting as invalid
     validMask_       = 0;
@@ -1047,7 +1047,7 @@ public class GStyle
     }
 
     // Add the listener
-    listeners_.add (new WeakReference (listener));
+    listeners_.add (new WeakReference<> (listener));
   }
 
 

--- a/src/main/java/no/geosoft/cc/graphics/GWindow.java
+++ b/src/main/java/no/geosoft/cc/graphics/GWindow.java
@@ -67,7 +67,7 @@ public class GWindow
   private int           width_;
   private int           height_;
   private GInteraction  interaction_;
-  private List          scenes_;
+  private List<GScene>  scenes_;
   private GScene        interactionScene_;
   private Region        damageRegion_;
 
@@ -87,7 +87,7 @@ public class GWindow
       canvas_.setBackground (backgroundColor);
     
     interaction_  = null;
-    scenes_       = new ArrayList();
+    scenes_       = new ArrayList<>();
     damageRegion_ = new Region();
 
     // Cannot set 0 initially as resize is computed relative to current

--- a/src/test/clojure/conexp/gui/gcanvas_buttons_test.clj
+++ b/src/test/clojure/conexp/gui/gcanvas_buttons_test.clj
@@ -1,0 +1,76 @@
+;; Copyright ⓒ the conexp-clj developers; all rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file LICENSE at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns conexp.gui.gcanvas-buttons-test
+  "Tests the translation from AWT mouse events to GWindow button constants.
+
+  The lattice editor cannot be clicked from a test, so the mapping is exercised
+  on synthetic events instead.  It used to read the deprecated modifier mask and
+  compare it for equality, which reported any click with a modifier held as a
+  button 3 click."
+  (:require [clojure.test :refer :all])
+  (:import [java.awt.event InputEvent MouseEvent]
+           [javax.swing JPanel]))
+
+;; a lightweight component, so the events can be built without a display
+
+(def ^:private button-event-of
+  (doto (.getDeclaredMethod no.geosoft.cc.graphics.GCanvas "buttonEventOf"
+                            (into-array Class [MouseEvent Integer/TYPE
+                                               Integer/TYPE Integer/TYPE]))
+    (.setAccessible true)))
+
+(def ^:private dragged-button-event-of
+  (doto (.getDeclaredMethod no.geosoft.cc.graphics.GCanvas "draggedButtonEventOf"
+                            (into-array Class [MouseEvent Integer/TYPE
+                                               Integer/TYPE Integer/TYPE]))
+    (.setAccessible true)))
+
+(defn- press
+  "A press event for `button`, with `modifiers` also held."
+  [button modifiers]
+  (MouseEvent. (JPanel.) MouseEvent/MOUSE_PRESSED 0 modifiers 10 10 1 false button))
+
+(defn- drag
+  "A drag event with `modifiers` held; a drag reports no button of its own."
+  [modifiers]
+  (MouseEvent. (JPanel.) MouseEvent/MOUSE_DRAGGED 0 modifiers 10 10 0 false
+               MouseEvent/NOBUTTON))
+
+(defn- mapped [^java.lang.reflect.Method m event]
+  (.invoke m nil (into-array Object [event (int 1) (int 2) (int 3)])))
+
+(deftest test-press-and-release-map-by-button
+  (are [button expected] (= expected (mapped button-event-of (press button 0)))
+    MouseEvent/BUTTON1 1
+    MouseEvent/BUTTON2 2
+    MouseEvent/BUTTON3 3))
+
+(deftest test-a-held-modifier-does-not-change-the-button
+  (testing "shift, control and alt held during the click.  Comparing the whole
+            modifier mask for equality used to report all of these as button 3."
+    (doseq [modifier [InputEvent/SHIFT_DOWN_MASK
+                      InputEvent/CTRL_DOWN_MASK
+                      InputEvent/ALT_DOWN_MASK]]
+      (is (= 1 (mapped button-event-of (press MouseEvent/BUTTON1 modifier)))
+          (str "button 1 with modifier " modifier))
+      (is (= 2 (mapped button-event-of (press MouseEvent/BUTTON2 modifier)))
+          (str "button 2 with modifier " modifier)))))
+
+(deftest test-drag-maps-by-the-button-held
+  (are [modifiers expected] (= expected (mapped dragged-button-event-of (drag modifiers)))
+    InputEvent/BUTTON1_DOWN_MASK 1
+    InputEvent/BUTTON2_DOWN_MASK 2
+    InputEvent/BUTTON3_DOWN_MASK 3
+    (bit-or InputEvent/BUTTON1_DOWN_MASK InputEvent/SHIFT_DOWN_MASK) 1
+    (bit-or InputEvent/BUTTON2_DOWN_MASK InputEvent/CTRL_DOWN_MASK) 2
+    0 3))
+
+;;;
+
+nil

--- a/src/test/clojure/conexp/gui/graphics_test.clj
+++ b/src/test/clojure/conexp/gui/graphics_test.clj
@@ -1,0 +1,62 @@
+;; Copyright ⓒ the conexp-clj developers; all rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file LICENSE at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns conexp.gui.graphics-test
+  "Tests for the bundled G graphics library the lattice editor draws on.
+
+  The editor cannot be driven from a test, but a scene can be built and
+  searched without a display, which covers the object and segment collections
+  and the picking methods that walk them."
+  (:require [clojure.test :refer :all])
+  (:import [no.geosoft.cc.graphics GObject GScene GSegment GWindow]))
+
+(defn- scene-with-a-square
+  "A scene holding one object with a single square segment from (0,0) to
+  (20,20), in a world 100 by 100."
+  []
+  (let [window  (GWindow.)
+        scene   (GScene. window "test")
+        object  (GObject. "square")
+        segment (GSegment.)]
+    (.add scene object)
+    (.addSegment object segment)
+    (.setGeometry segment (int-array [0 0 20 0 20 20 0 20 0 0]))
+    (.setWorldExtent scene 0.0 0.0 100.0 100.0)
+    (.setSize (.getCanvas window) 100 100)
+    (.refresh scene)
+    [scene object segment]))
+
+(deftest test-object-holds-its-segments-and-children
+  (let [[_ object segment] (scene-with-a-square)
+        child (GObject. "child")]
+    (is (= [segment] (vec (.getSegments object))))
+    (.add object child)
+    (is (= [child] (vec (.getChildren object))))
+    (.remove object child)
+    (is (empty? (.getChildren object)))))
+
+(deftest test-picking-a-point
+  (testing "a point on the outline finds the segment and its object"
+    (let [[_ object segment] (scene-with-a-square)]
+      (is (= [segment] (vec (.findSegments object 10 0))))
+      (is (= [object] (vec (.findAll object 10 0))))))
+  (testing "a point well away from it finds nothing"
+    (let [[_ object _] (scene-with-a-square)]
+      (is (empty? (.findSegments object 90 90)))
+      (is (empty? (.findAll object 90 90))))))
+
+(deftest test-picking-a-rectangle
+  (let [[_ object segment] (scene-with-a-square)]
+    (testing "a rectangle meeting the outline finds it"
+      (is (= [segment] (vec (.findSegments object 0 0 30 30)))))
+    (testing "a rectangle missing it does not"
+      (is (empty? (.findSegments object 60 60 90 90))))))
+
+;;;
+
+nil


### PR DESCRIPTION
Building an uberjar printed:

```
Note: Some input files use or override a deprecated API.
Note: Some input files use unchecked or unsafe operations.
```

Those came from the bundled G graphics library, the last 23 warnings after #192 cleared LatDraw. **There are none now**, across all Java, so the notes are gone.

## Fourteen raw collections

The object and segment lists of `GObject`, the text, image and component collections of `GSegment`, the listener list of `GStyle`, the scene list of `GWindow`, and the accumulator parameters and return types of the picking methods that walk them. All typed.

## Nine deprecations, and a real bug behind them

`InputEvent.getModifiers` and `BUTTON1_MASK`/`BUTTON2_MASK` have been deprecated since Java 9. Replacing them turned up a genuine bug: the old code compared the **whole** modifier mask for equality.

```java
int modifiers = event.getModifiers();
if      (modifiers == event.BUTTON1_MASK) buttonEvent = GWindow.BUTTON1_DOWN;
else if (modifiers == event.BUTTON2_MASK) buttonEvent = GWindow.BUTTON2_DOWN;
else                                      buttonEvent = GWindow.BUTTON3_DOWN;
```

Hold any modifier while clicking and the mask matches neither branch, so it falls through to button 3. **Shift-clicking or control-clicking a node in the lattice editor was reported as a right click.**

Presses and releases now ask `getButton`, which names the button that caused the event whatever else is held. Drags ask `getModifiersEx` instead, since a drag event reports no button of its own.

## Testing something that needs a mouse

The editor cannot be clicked from a test, so the mapping moved into two small helpers and the tests feed them synthetic events: all three buttons plain, and buttons 1 and 2 with shift, control and alt held, plus the drag cases.

I checked the tests earn their keep rather than merely passing. Reinstating the old mask comparison fails all six modifier cases; restoring the fix turns them green.

A second new test builds a `GScene` without a display and picks points and rectangles out of it, which covers the collections and picking methods this pull request retyped.

## Unchanged behaviour

Freese layouts compared against the same ten lattices used in #192, at four projection angles each: all identical.

Full suite: 610 tests, no failures. Uberjar builds with no notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PURHiEwvBNn1EsXfgN9xBa